### PR TITLE
Validate Phase 1 CI and contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Thanks for helping improve Europe Visa Sponsorship Jobs.
+
+The project is designed to become community-driven once public. Accuracy matters more than job volume: a false claim that a vacancy supports immigration can waste a candidate's time.
+
+## Phase 1 contribution areas
+
+Contributions are especially useful for:
+
+- ATS connectors and parser fixtures
+- European country-rule metadata
+- verified official sponsor-registry data
+- visa/work-permit signal phrases
+- hard restriction phrases
+- country and city normalization
+- technical role classification
+- tests and documentation
+
+## Non-negotiable rules
+
+1. **No paid LLM/API dependency.** Phase 1 must run without OpenAI, Anthropic, Gemini, or similar services.
+2. **Evidence over guesses.** Missing evidence should produce `unknown`, not `eligible`.
+3. **Hard negatives win.** Existing-work-authorization, citizenship, EU/EEA-only, or no-sponsorship restrictions must override positive wording.
+4. **A sponsor company does not imply every job is sponsored.** Vacancy-level evidence is still required.
+5. **Prefer first-party sources.** Use documented/public company ATS feeds and official immigration/sponsor sources where possible.
+6. **Do not bypass authentication, anti-bot controls, or website restrictions.**
+7. **Add tests with behavior changes.**
+
+## Development setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+alembic upgrade head
+```
+
+Run the quality suite:
+
+```bash
+python -m compileall -q src
+ruff check src tests
+pytest --cov=europe_visa_jobs --cov-report=term-missing --cov-fail-under=85
+```
+
+Migration smoke test:
+
+```bash
+DATABASE_URL=sqlite:///./migration_check.db alembic upgrade head
+DATABASE_URL=sqlite:///./migration_check.db alembic downgrade base
+```
+
+## Adding an ATS connector
+
+A connector must:
+
+- inherit from `BaseConnector`
+- consume a public job feed
+- return `list[NormalizedJob]`
+- keep provider parsing separate from eligibility logic
+- preserve the canonical apply URL
+- include mocked connector tests
+- raise `ConnectorError` for malformed/unavailable feeds
+
+Register it in `connectors/factory.py` only after tests exist.
+
+## Adding or changing visa rules
+
+Country route metadata belongs in `eligibility/country_rules.py`.
+
+Textual sponsorship/restriction evidence belongs in `eligibility/signals.py`.
+
+Do not hard-code volatile salary thresholds into regex rules. Time-sensitive legal thresholds should be maintained as dated datasets with an official source.
+
+## Pull requests
+
+Before opening a PR:
+
+- run the full test suite
+- run Ruff
+- run the migration smoke test for schema changes
+- document new public data sources
+- explain false-positive/false-negative implications for eligibility changes
+
+The project deliberately prefers false negatives over false positives for the default user-facing job list.

--- a/src/europe_visa_jobs/eligibility/signals.py
+++ b/src/europe_visa_jobs/eligibility/signals.py
@@ -18,7 +18,7 @@ class SponsorshipSignalDetector:
     """Deterministic job-description signal detector with hard-negative precedence."""
 
     HARD_NEGATIVE_PATTERNS: tuple[tuple[str, str, str], ...] = (
-        ("no_sponsorship", r"\b(?:do(?:es)?\s+not|don['’]?t|cannot|can['’]?t|unable\s+to|not\s+able\s+to|will\s+not|won['’]?t)\s+(?:provide|offer|support|sponsor)?\s*(?:visa|work\s+permit|immigration)\s*(?:sponsorship|support)?\b", "Employer explicitly says sponsorship or immigration support is unavailable."),
+        ("no_sponsorship", r"\b(?:do(?:es)?\s+not|don(?:'|\u2019)?t|cannot|can(?:'|\u2019)?t|unable\s+to|not\s+able\s+to|will\s+not|won(?:'|\u2019)?t)\s+(?:provide|offer|support|sponsor)?\s*(?:visa|work\s+permit|immigration)\s*(?:sponsorship|support)?\b", "Employer explicitly says sponsorship or immigration support is unavailable."),
         ("no_sponsorship_direct", r"\bno\s+(?:visa\s+)?sponsorship\b|\b(?:visa\s+)?sponsorship\s+(?:is|will\s+be)\s+not\s+(?:available|provided|offered)\b", "Vacancy explicitly states that sponsorship is unavailable."),
         ("without_sponsorship", r"\b(?:authorized|authorised|eligible)\s+to\s+work\b.{0,80}\bwithout\s+(?:current\s+or\s+future\s+)?sponsorship\b", "Existing work authorization without sponsorship is required."),
         ("existing_work_rights", r"\bmust\s+(?:already\s+)?(?:have|hold)\s+(?:the\s+)?(?:legal\s+)?right\s+to\s+work\b", "Existing local work rights are required."),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,6 +1,11 @@
 from europe_visa_jobs.db.repository import Repository
 from europe_visa_jobs.eligibility import EligibilityEngine
-from europe_visa_jobs.schemas import ATSProvider, CompanySponsorEvidence, EligibilityStatus, NormalizedJob
+from europe_visa_jobs.schemas import (
+    ATSProvider,
+    CompanySponsorEvidence,
+    EligibilityStatus,
+    NormalizedJob,
+)
 
 
 def sample_job(external_id: str = "1") -> NormalizedJob:


### PR DESCRIPTION
Runs the complete Phase 1 CI matrix against the implemented core platform and adds contribution rules for future community work.

Validation target:
- Python 3.11 / 3.12
- compileall
- Ruff
- Alembic upgrade/downgrade smoke test
- pytest with >=85% coverage

No LLM or paid AI dependency is introduced.