### PR TITLE
Phase 2 - Candidate Intelligence Engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src:.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Tests with coverage
         run: pytest --cov=europe_visa_jobs --cov-report=term-missing --cov-fail-under=85
+
+      - name: Docker build
+        run: docker build --tag europe-visa-sponsorship-jobs:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
         run: python -m compileall -q src
 
       - name: Lint
-        run: ruff check src tests
+        run: ruff check src tests scripts
+
+      - name: Type check
+        run: mypy src scripts --ignore-missing-imports
 
       - name: Migration smoke test
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 COPY pyproject.toml README.md alembic.ini ./
 COPY migrations ./migrations
 COPY src ./src
+COPY config ./config
+COPY data ./data
+COPY scripts ./scripts
 RUN pip install --upgrade pip && pip install ".[postgres]"
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -247,6 +247,24 @@ pytest --cov=europe_visa_jobs --cov-report=term-missing --cov-fail-under=85
 
 CI also runs compilation, Ruff, and the coverage gate on pushes and pull requests.
 
+## Phase 2 status
+
+**Phase 2 — Candidate Intelligence & Matching Engine: implemented.**
+
+Implemented:
+
+- Candidate profile persistence and validation
+- Target roles, canonical skills, experience, seniority, country, visa, relocation, remote, and exclusion preferences
+- Deterministic skill ontology with aliases, categories, and explainable extraction
+- Required/preferred job skill analysis and experience/seniority extraction
+- Candidate-specific visa, skill, role, experience, country, and company matching
+- Configurable 35/30/15/10/10 recommendation ranking
+- Company friendliness scoring from Phase 1 sponsor and vacancy evidence
+- Explainable recommendation and detailed explanation endpoints
+- Fixture-backed ranking regression tests for Phase 2
+
+See [`docs/PHASE_2.md`](docs/PHASE_2.md) for the matching architecture, scoring formula, and API examples.
+
 ## Current job families
 
 - Software Engineering

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ docker compose up --build
 
 API: `http://localhost:8000`
 
+### Run the fictional demo dataset
+
+The demo records are deterministic and clearly marked as sample data. They do not assert that
+any named company sponsors visas or that any vacancy is real.
+
+```bash
+python scripts/seed_demo.py
+```
+
+To use a separate local database:
+
+```bash
+python scripts/seed_demo.py --database-url sqlite:///./demo.db
+```
+
 ## Configure job sources
 
 Copy the example:
@@ -211,6 +226,7 @@ Filters:
 GET /api/v1/jobs?country=Germany
 GET /api/v1/jobs?country=Netherlands&job_family=ai_ml
 GET /api/v1/jobs?status=unknown
+GET /api/v1/jobs?category=ai_ml&visa_status=eligible&limit=20&offset=20
 ```
 
 ### Job evidence
@@ -239,13 +255,37 @@ GET /api/v1/countries
 GET /api/v1/stats
 ```
 
+### Candidate recommendations
+
+```http
+POST /api/v1/candidates
+GET  /api/v1/candidates/{candidate_id}
+GET  /api/v1/recommendations/{candidate_id}
+GET  /api/v1/recommendations/{candidate_id}/explain
+```
+
+Recommendation queries support `country`, `role`, `min_score`, `limit`, `offset`, and
+`include_unknown`. Responses remain JSON lists for backward compatibility and include an
+`X-Total-Count` header. Each item includes a frontend-friendly `scores` object alongside the
+legacy flat score fields:
+
+```json
+{
+  "job": {"id": 42, "title": "Senior AI Engineer"},
+  "scores": {"overall": 92, "visa": 100, "skill": 90, "experience": 88, "country": 100, "company": 75},
+  "reasons": ["The job passed the strict sponsorship eligibility gate."],
+  "warnings": ["Missing required skills: Kubernetes."]
+}
+```
+
 ## Tests
 
 ```bash
 pytest --cov=europe_visa_jobs --cov-report=term-missing --cov-fail-under=85
+mypy src --ignore-missing-imports
 ```
 
-CI also runs compilation, Ruff, and the coverage gate on pushes and pull requests.
+CI also runs compilation, Ruff, mypy, migrations, coverage, and the Docker image build on pull requests.
 
 ## Phase 2 status
 
@@ -259,9 +299,12 @@ Implemented:
 - Required/preferred job skill analysis and experience/seniority extraction
 - Candidate-specific visa, skill, role, experience, country, and company matching
 - Configurable 35/30/15/10/10 recommendation ranking
+- File-backed ranking weights in [`config/ranking.yaml`](config/ranking.yaml)
+- File-backed skill aliases/categories in [`data/skills.yaml`](data/skills.yaml)
 - Company friendliness scoring from Phase 1 sponsor and vacancy evidence
 - Explainable recommendation and detailed explanation endpoints
 - Fixture-backed ranking regression tests for Phase 2
+- Deterministic fictional demo seed script for local UI development
 
 See [`docs/PHASE_2.md`](docs/PHASE_2.md) for the matching architecture, scoring formula, and API examples.
 

--- a/config/ranking.yaml
+++ b/config/ranking.yaml
@@ -1,0 +1,11 @@
+# Deterministic recommendation weights. Values must be non-negative and sum to 1.0.
+visa_score:
+  weight: 0.35
+skill_score:
+  weight: 0.30
+experience_score:
+  weight: 0.15
+country_score:
+  weight: 0.10
+company_score:
+  weight: 0.10

--- a/data/skills.yaml
+++ b/data/skills.yaml
@@ -1,0 +1,122 @@
+# Curated, deterministic skill ontology. Add aliases here instead of changing matching code.
+skills:
+  - canonical: Python
+    aliases: [python, python3, python programming]
+    categories: [programming]
+  - canonical: Java
+    aliases: [java]
+    categories: [programming]
+  - canonical: JavaScript
+    aliases: [javascript, java script, js]
+    categories: [programming]
+  - canonical: TypeScript
+    aliases: [typescript, type script, ts]
+    categories: [programming]
+  - canonical: Go
+    aliases: [golang, go language]
+    categories: [programming]
+  - canonical: Rust
+    aliases: [rust programming]
+    categories: [programming]
+  - canonical: C++
+    aliases: [c++, cpp]
+    categories: [programming]
+  - canonical: SQL
+    aliases: [sql, structured query language]
+    categories: [data]
+  - canonical: PyTorch
+    aliases: [pytorch, torch, pytorch framework]
+    categories: [machine_learning]
+  - canonical: TensorFlow
+    aliases: [tensorflow, tensor flow]
+    categories: [machine_learning]
+  - canonical: scikit-learn
+    aliases: [scikit-learn, sklearn, scikit learn]
+    categories: [machine_learning]
+  - canonical: LLM
+    aliases: [llm, large language model, large language models, generative ai, genai, generative artificial intelligence]
+    categories: [machine_learning]
+  - canonical: RAG
+    aliases: [rag, retrieval augmented generation, retrieval-augmented generation]
+    categories: [machine_learning]
+  - canonical: Natural Language Processing
+    aliases: [nlp, natural language processing]
+    categories: [machine_learning]
+  - canonical: Computer Vision
+    aliases: [computer vision, cv models]
+    categories: [machine_learning]
+  - canonical: MLflow
+    aliases: [mlflow, ml flow]
+    categories: [machine_learning]
+  - canonical: Kubernetes
+    aliases: [kubernetes, k8s]
+    categories: [cloud]
+  - canonical: Docker
+    aliases: [docker, docker containers]
+    categories: [cloud]
+  - canonical: AWS
+    aliases: [aws, amazon web services]
+    categories: [cloud]
+  - canonical: Azure
+    aliases: [azure, microsoft azure]
+    categories: [cloud]
+  - canonical: Google Cloud
+    aliases: [google cloud, gcp]
+    categories: [cloud]
+  - canonical: Terraform
+    aliases: [terraform]
+    categories: [cloud]
+  - canonical: CI/CD
+    aliases: [ci/cd, cicd, continuous integration, continuous delivery]
+    categories: [devops]
+  - canonical: Linux
+    aliases: [linux]
+    categories: [infrastructure]
+  - canonical: Git
+    aliases: [git, git version control]
+    categories: [tools]
+  - canonical: React
+    aliases: [react, react.js, reactjs]
+    categories: [frontend]
+  - canonical: Vue.js
+    aliases: [vue, vue.js, vuejs]
+    categories: [frontend]
+  - canonical: Angular
+    aliases: [angular]
+    categories: [frontend]
+  - canonical: Node.js
+    aliases: [node, node.js, nodejs]
+    categories: [backend]
+  - canonical: Django
+    aliases: [django]
+    categories: [backend]
+  - canonical: FastAPI
+    aliases: [fastapi, fast api]
+    categories: [backend]
+  - canonical: Spring
+    aliases: [spring boot, spring framework]
+    categories: [backend]
+  - canonical: PostgreSQL
+    aliases: [postgresql, postgres, postgre sql]
+    categories: [databases]
+  - canonical: Redis
+    aliases: [redis]
+    categories: [databases]
+  - canonical: Kafka
+    aliases: [kafka, apache kafka]
+    categories: [data]
+  - canonical: Spark
+    aliases: [spark, apache spark, pyspark]
+    categories: [data]
+  - canonical: Airflow
+    aliases: [airflow, apache airflow]
+    categories: [data]
+  - canonical: dbt
+    aliases: [dbt, data build tool]
+    categories: [data]
+  - canonical: Prometheus
+    aliases: [prometheus]
+    categories: [observability]
+  - canonical: Grafana
+    aliases: [grafana]
+    categories: [observability]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Phase 1 Architecture
+# Phase 1–2 Architecture
 
 ## Design goals
 
@@ -18,6 +18,7 @@ src/europe_visa_jobs/
 ├── connectors/     ATS-specific public feed adapters
 ├── db/             SQLAlchemy models, session, repository
 ├── eligibility/    country rules, sponsor evidence, signal detector, engine
+├── intelligence/   skill ontology, job analysis, matching, ranking, company scoring
 ├── ingestion/      source loading, sponsor import, ingestion pipeline, CLI
 ├── utils/          text, country and role normalization
 ├── schemas.py      shared Pydantic domain models
@@ -102,6 +103,10 @@ Tables:
 - `jobs`
 - `job_evidence`
 - `ingestion_runs`
+- `candidates`
+
+Phase 2 adds persisted job intelligence fields (`required_skills`, `preferred_skills`, minimum
+experience, and seniority) while retaining runtime analysis for legacy rows.
 
 The unique job identity is:
 

--- a/docs/PHASE_2.md
+++ b/docs/PHASE_2.md
@@ -46,7 +46,7 @@ Candidate input can use aliases. For example, `python3`, `Torch`, `GenAI`, and `
 
 ## Skill ontology
 
-`SkillOntology` is a reviewed taxonomy in `intelligence/ontology.py`. Each definition has a canonical name, category, and aliases. Extraction uses case-insensitive, boundary-aware regular expressions and returns stable, de-duplicated output.
+`SkillOntology` loads the reviewed taxonomy from [`data/skills.yaml`](../data/skills.yaml). Each definition has a canonical name, category, and aliases. Extraction uses case-insensitive, boundary-aware regular expressions and returns stable, de-duplicated output. A built-in fallback keeps installed packages safe if the repository data file is unavailable.
 
 The ontology currently covers programming, machine learning, cloud, infrastructure, frontend/backend, databases, data, DevOps, and observability skills. Unknown candidate-entered skills are preserved as labels; only known ontology skills are extracted from job text.
 
@@ -70,7 +70,7 @@ Hard restrictions remain warnings and never become positive sponsorship evidence
 
 ## Ranking
 
-The default ranking weights are configurable through `RankingConfig`:
+The default ranking weights are stored in [`config/ranking.yaml`](../config/ranking.yaml) and loaded through `RankingConfig`/`load_ranking_config`. Applications can still inject `RankingConfig` directly for tests or tenant-specific policies:
 
 | Component | Weight |
 |---|---:|
@@ -92,9 +92,9 @@ Negative signals include no sponsorship, existing-work-rights requirements, EU/E
 
 The score is a signal summary, not a legal guarantee. Vacancy-level evidence remains separate and auditable.
 
-## API
+## Frontend API contract
 
-Both `/api/v1/...` and the short paths in the Phase 2 brief are available. The versioned paths are the documented interface:
+The versioned endpoints are the stable Phase 3 interface. Both `/api/v1/...` and the short paths in the Phase 2 brief are available:
 
 ```http
 POST /api/v1/candidates
@@ -103,10 +103,25 @@ GET  /api/v1/recommendations/{candidate_id}
 GET  /api/v1/recommendations/{candidate_id}/explain
 ```
 
-Recommendations return the job, all component scores, skill coverage, matched/missing skills, reasons, and warnings. The default recommendation catalog contains active Phase 1 eligible jobs. `include_unknown=true` is available for research and audit use.
+Recommendation responses remain lists for backward compatibility. Each recommendation includes a complete `job` payload, grouped `scores` (`overall`, `visa`, `skill`, `experience`, `country`, and `company`, all 0–100), skill coverage, matched/missing skills, `reasons`, and `warnings`. Recommendation filters are `country`, `role`, and `min_score`; `limit` and `offset` provide simple pagination, and `X-Total-Count` reports the filtered result count. `include_unknown=true` is opt-in for research and audit use. The jobs endpoint keeps `status`, `country`, and `job_family` and also accepts the UI aliases `visa_status` and `category`.
+
+Example item:
+
+```json
+{
+  "job": {"id": 42, "title": "Senior AI Engineer"},
+  "scores": {"overall": 92, "visa": 100, "skill": 90, "experience": 88, "country": 100, "company": 75},
+  "reasons": ["The job passed the strict sponsorship eligibility gate."],
+  "warnings": ["Missing required skills: Kubernetes."]
+}
+```
 
 ## Evaluation
 
-`tests/fixtures/` contains a representative senior ML candidate, three jobs, and an expected ranking. Regression tests verify alias normalization, ranking order, missing-skill warnings, excluded locations, API serialization, and the persisted profile fields.
+`tests/fixtures/` contains a representative senior ML candidate, three jobs, and an expected ranking. Regression tests verify alias normalization, ranking order, missing-skill warnings, excluded locations, API serialization, pagination/filter behavior, configuration loading, demo seeding, and persisted profile fields.
+
+## Demo usage
+
+Run `python scripts/seed_demo.py` after installing the project. It creates three fictional candidates and three fictional European jobs. Every demo description contains `DEMO SAMPLE DATA ONLY`; the dataset is not evidence about real employers, vacancies, or sponsorship status. The script is idempotent for candidates and upserts the sample jobs.
 
 This layer is ready for Phase 3 to build onboarding, search, job detail, and explanation views without duplicating backend scoring logic.

--- a/docs/PHASE_2.md
+++ b/docs/PHASE_2.md
@@ -1,0 +1,29 @@
+# Phase 2 — Candidate Intelligence Engine
+
+## Goal
+
+Transform the Phase 1 job intelligence platform into a personalized recommendation engine without requiring LLMs or paid APIs.
+
+## Principles
+
+- Deterministic and explainable scoring
+- No external AI API dependency
+- Reusable skill taxonomy
+- Evidence-based recommendations
+
+## Components
+
+- Candidate profiles
+- Skill normalization
+- Job matching
+- Ranking engine
+- Recommendation explanations
+- Evaluation datasets
+
+## Planned scoring
+
+- Visa eligibility: 35%
+- Skill match: 30%
+- Experience match: 15%
+- Country preference: 10%
+- Company intelligence: 10%

--- a/docs/PHASE_2.md
+++ b/docs/PHASE_2.md
@@ -1,29 +1,112 @@
-# Phase 2 — Candidate Intelligence Engine
+# Phase 2 — Candidate Intelligence & Matching Engine
 
-## Goal
+Phase 2 turns the Phase 1 eligible-job catalog into personalized, deterministic recommendations. The backend answers which jobs are worth an individual candidate's time and records the reasons and warnings behind each score.
 
-Transform the Phase 1 job intelligence platform into a personalized recommendation engine without requiring LLMs or paid APIs.
+## Architecture
 
-## Principles
+```text
+Candidate profile
+    │
+    ├── canonical skill aliases
+    ├── target role families
+    ├── experience and seniority
+    ├── country / location preferences
+    └── visa, relocation, and remote preferences
+    │
+    ▼
+Job intelligence extraction
+    │  required/preferred skills, minimum experience, seniority
+    ▼
+CandidateMatcher
+    │  visa, skills, experience, role, country, company signals
+    ▼
+RankingEngine
+    │  configurable weighted score
+    ▼
+Recommendation API
+```
 
-- Deterministic and explainable scoring
-- No external AI API dependency
-- Reusable skill taxonomy
-- Evidence-based recommendations
+The implementation is local and deterministic. It does not call an LLM, paid AI API, embedding service, or external repository at runtime.
 
-## Components
+## Candidate profile
 
-- Candidate profiles
-- Skill normalization
-- Job matching
-- Ranking engine
-- Recommendation explanations
-- Evaluation datasets
+`Candidate` stores:
 
-## Planned scoring
+- target roles
+- canonical skills
+- years of experience
+- seniority
+- preferred countries
+- visa requirement
+- relocation preference
+- remote preference
+- excluded locations
 
-- Visa eligibility: 35%
-- Skill match: 30%
-- Experience match: 15%
-- Country preference: 10%
-- Company intelligence: 10%
+Candidate input can use aliases. For example, `python3`, `Torch`, `GenAI`, and `K8s` are stored as `Python`, `PyTorch`, `LLM`, and `Kubernetes`.
+
+## Skill ontology
+
+`SkillOntology` is a reviewed taxonomy in `intelligence/ontology.py`. Each definition has a canonical name, category, and aliases. Extraction uses case-insensitive, boundary-aware regular expressions and returns stable, de-duplicated output.
+
+The ontology currently covers programming, machine learning, cloud, infrastructure, frontend/backend, databases, data, DevOps, and observability skills. Unknown candidate-entered skills are preserved as labels; only known ontology skills are extracted from job text.
+
+Job descriptions recognize preferred-skill markers such as `nice to have`, `preferred`, `bonus`, `plus`, and `desirable`. Skills outside those passages are treated as required. Existing Phase 1 jobs without persisted intelligence fields are analyzed at match time, so the migration is backwards-compatible.
+
+## Matching
+
+The matcher calculates:
+
+- required skill coverage
+- preferred skill coverage
+- a 70/30 skill score from required/preferred coverage
+- seniority match
+- minimum-experience match
+- target-role similarity using the Phase 1 role classifier
+- country and location preference match
+- candidate-specific visa eligibility
+- company friendliness from Phase 1 evidence
+
+Hard restrictions remain warnings and never become positive sponsorship evidence. A candidate who requires a visa receives a full visa score only for a Phase 1 `eligible` job; `unknown` receives a low score and `rejected` receives zero.
+
+## Ranking
+
+The default ranking weights are configurable through `RankingConfig`:
+
+| Component | Weight |
+|---|---:|
+| Visa eligibility | 35% |
+| Skill match | 30% |
+| Experience match | 15% |
+| Country preference | 10% |
+| Company intelligence | 10% |
+
+Every weight is validated as non-negative and the total must equal 100%. The final score is normalized to 0–100. Recommendations are sorted by total score, then posting date, then stable job id.
+
+## Company intelligence
+
+The company score starts from a conservative baseline and uses persisted Phase 1 signals:
+
+Positive signals include recognized sponsor evidence, relocation support, international-candidate language, applications from abroad, and explicit visa/work-permit support.
+
+Negative signals include no sponsorship, existing-work-rights requirements, EU/EEA-only restrictions, local-only hiring, and citizenship restrictions.
+
+The score is a signal summary, not a legal guarantee. Vacancy-level evidence remains separate and auditable.
+
+## API
+
+Both `/api/v1/...` and the short paths in the Phase 2 brief are available. The versioned paths are the documented interface:
+
+```http
+POST /api/v1/candidates
+GET  /api/v1/candidates/{candidate_id}
+GET  /api/v1/recommendations/{candidate_id}
+GET  /api/v1/recommendations/{candidate_id}/explain
+```
+
+Recommendations return the job, all component scores, skill coverage, matched/missing skills, reasons, and warnings. The default recommendation catalog contains active Phase 1 eligible jobs. `include_unknown=true` is available for research and audit use.
+
+## Evaluation
+
+`tests/fixtures/` contains a representative senior ML candidate, three jobs, and an expected ranking. Regression tests verify alias normalization, ranking order, missing-skill warnings, excluded locations, API serialization, and the persisted profile fields.
+
+This layer is ready for Phase 3 to build onboarding, search, job detail, and explanation views without duplicating backend scoring logic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,7 @@ The project is intentionally divided into four delivery phases.
 - [x] Optional scheduled ingestion workflow
 - [x] No LLM / no paid AI API dependency
 
-## Phase 2 — Candidate Matching & Intelligence
+## Phase 2 — Candidate Matching & Intelligence ✅
 
 - [x] Candidate profile
 - [x] Role preferences and experience level

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,15 +32,15 @@ The project is intentionally divided into four delivery phases.
 
 ## Phase 2 — Candidate Matching & Intelligence
 
-- [ ] Candidate profile
-- [ ] Role preferences and experience level
-- [ ] Skill taxonomy
-- [ ] Skill aliases/synonyms
-- [ ] Deterministic CV/profile parsing where practical
-- [ ] Job-to-profile match score
-- [ ] Country preferences
-- [ ] Candidate-specific eligibility checks
-- [ ] Explainable ranking
+- [x] Candidate profile
+- [x] Role preferences and experience level
+- [x] Skill taxonomy
+- [x] Skill aliases/synonyms
+- [x] Deterministic CV/profile parsing where practical
+- [x] Job-to-profile match score
+- [x] Country preferences
+- [x] Candidate-specific eligibility checks
+- [x] Explainable ranking
 - [ ] Saved jobs and application state
 
 ## Phase 3 — Professional UI/UX

--- a/migrations/versions/0002_phase2_candidate_intelligence.py
+++ b/migrations/versions/0002_phase2_candidate_intelligence.py
@@ -1,0 +1,47 @@
+"""Candidate intelligence and persisted job profile fields.
+
+Revision ID: 0002_phase2_candidate_intelligence
+Revises: 0001_phase1_core
+Create Date: 2026-08-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_phase2_candidate_intelligence"
+down_revision = "0001_phase1_core"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "candidates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("target_roles", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("skills", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("years_of_experience", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("seniority", sa.String(length=50), nullable=True),
+        sa.Column("preferred_countries", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("visa_required", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("relocation_preference", sa.String(length=30), nullable=False, server_default="preferred"),
+        sa.Column("remote_preference", sa.String(length=30), nullable=False, server_default="no_preference"),
+        sa.Column("excluded_locations", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.add_column("jobs", sa.Column("required_skills", sa.JSON(), nullable=False, server_default=sa.text("'[]'")))
+    op.add_column("jobs", sa.Column("preferred_skills", sa.JSON(), nullable=False, server_default=sa.text("'[]'")))
+    op.add_column("jobs", sa.Column("min_experience_years", sa.Float(), nullable=True))
+    op.add_column("jobs", sa.Column("seniority", sa.String(length=50), nullable=True))
+    op.create_index("ix_jobs_seniority", "jobs", ["seniority"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_seniority", table_name="jobs")
+    op.drop_column("jobs", "seniority")
+    op.drop_column("jobs", "min_experience_years")
+    op.drop_column("jobs", "preferred_skills")
+    op.drop_column("jobs", "required_skills")
+    op.drop_table("candidates")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "pytest-cov>=6,<8",
   "mypy>=1.13,<2",
   "ruff>=0.9,<1",
+  "types-PyYAML>=6,<7",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "beautifulsoup4>=4.12,<5",
   "fastapi>=0.115,<1",
   "httpx>=0.27,<1",
+  "PyYAML>=6,<7",
   "pydantic>=2.10,<3",
   "pydantic-settings>=2.7,<3",
   "sqlalchemy>=2.0,<3",
@@ -28,6 +29,7 @@ dev = [
   "pytest>=8.3,<10",
   "pytest-asyncio>=0.24,<1",
   "pytest-cov>=6,<8",
+  "mypy>=1.13,<2",
   "ruff>=0.9,<1",
 ]
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance and demo scripts."""

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1,0 +1,146 @@
+"""Seed a small, clearly fictional dataset for local demos and screenshots."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+DEMO_CANDIDATES = (
+    {
+        "name": "Demo Candidate — Senior AI Engineer",
+        "target_roles": ["AI Engineer", "Machine Learning Engineer"],
+        "skills": ["Python", "PyTorch", "LLM", "RAG", "Kubernetes", "MLflow"],
+        "years_of_experience": 7,
+        "seniority": "senior",
+        "preferred_countries": ["Germany", "Netherlands", "Sweden"],
+        "visa_required": True,
+    },
+    {
+        "name": "Demo Candidate — Backend Engineer",
+        "target_roles": ["Backend Engineer"],
+        "skills": ["Python", "PostgreSQL", "Docker", "Kubernetes"],
+        "years_of_experience": 5,
+        "seniority": "senior",
+        "preferred_countries": ["Germany", "Sweden"],
+        "visa_required": True,
+    },
+    {
+        "name": "Demo Candidate — Data Scientist",
+        "target_roles": ["Data Scientist"],
+        "skills": ["Python", "SQL", "scikit-learn", "Spark"],
+        "years_of_experience": 4,
+        "seniority": "mid",
+        "preferred_countries": ["Sweden", "Germany"],
+        "visa_required": True,
+    },
+)
+
+DEMO_JOBS = (
+    {
+        "external_id": "demo-ai-berlin",
+        "company_name": "Demo Aurora AI GmbH (Sample)",
+        "title": "Senior Machine Learning Engineer",
+        "description": (
+            "DEMO SAMPLE DATA ONLY — not a real sponsorship claim. "
+            "Visa sponsorship and relocation support are available. "
+            "Required skills: Python, PyTorch, Kubernetes. Nice to have: MLflow."
+        ),
+        "location": "Berlin, Germany",
+        "country": "Germany",
+        "apply_url": "https://example.invalid/demo-ai-berlin",
+    },
+    {
+        "external_id": "demo-data-stockholm",
+        "company_name": "Demo Northstar Analytics AB (Sample)",
+        "title": "Data Scientist",
+        "description": (
+            "DEMO SAMPLE DATA ONLY — not a real sponsorship claim. "
+            "Work permit support and relocation assistance are available. "
+            "Required skills: Python, SQL, scikit-learn."
+        ),
+        "location": "Stockholm, Sweden",
+        "country": "Sweden",
+        "apply_url": "https://example.invalid/demo-data-stockholm",
+    },
+    {
+        "external_id": "demo-backend-amsterdam",
+        "company_name": "Demo Canal Systems B.V. (Sample)",
+        "title": "Backend Engineer",
+        "description": (
+            "DEMO SAMPLE DATA ONLY — not a real sponsorship claim. "
+            "Visa sponsorship and relocation support are mentioned for this sample vacancy. "
+            "Required skills: Python, PostgreSQL, Docker."
+        ),
+        "location": "Amsterdam, Netherlands",
+        "country": "Netherlands",
+        "apply_url": "https://example.invalid/demo-backend-amsterdam",
+    },
+)
+
+
+def seed_demo(session) -> tuple[int, int]:
+    """Insert or refresh demo jobs and insert demo candidates once.
+
+    Returns ``(jobs_upserted, candidates_created)``. No real company, vacancy, or sponsor
+    assertion is represented by this dataset.
+    """
+    from europe_visa_jobs.db.repository import Repository
+    from europe_visa_jobs.eligibility import EligibilityEngine
+    from europe_visa_jobs.schemas import ATSProvider, CandidateCreate, NormalizedJob
+    from europe_visa_jobs.utils import classify_role
+
+    repo = Repository(session)
+    engine = EligibilityEngine()
+    jobs_upserted = 0
+    for job_row in DEMO_JOBS:
+        job = NormalizedJob(
+            external_id=job_row["external_id"],
+            provider=ATSProvider.GREENHOUSE,
+            source_slug="demo",
+            company_name=job_row["company_name"],
+            title=job_row["title"],
+            description=job_row["description"],
+            location=job_row["location"],
+            country=job_row["country"],
+            apply_url=job_row["apply_url"],
+            job_url=job_row["apply_url"],
+            posted_at=datetime(2026, 1, 1, tzinfo=UTC),
+            job_family=classify_role(job_row["title"]),
+        )
+        repo.upsert_job(job, engine.assess(job))
+        jobs_upserted += 1
+
+    candidates_created = 0
+    for candidate_row in DEMO_CANDIDATES:
+        candidate_name = str(candidate_row["name"])
+        if repo.get_candidate_by_name(candidate_name) is not None:
+            continue
+        repo.create_candidate(CandidateCreate.model_validate(candidate_row))
+        candidates_created += 1
+    session.commit()
+    return jobs_upserted, candidates_created
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed clearly fictional Phase 2 demo records.")
+    parser.add_argument("--database-url", help="Database URL; defaults to DATABASE_URL/settings.")
+    args = parser.parse_args()
+    if args.database_url:
+        os.environ["DATABASE_URL"] = args.database_url
+
+    from europe_visa_jobs.db.session import SessionLocal, init_db
+
+    init_db()
+    with SessionLocal() as session:
+        jobs, candidates = seed_demo(session)
+    print(f"Seeded demo data only: {jobs} jobs upserted, {candidates} candidates created.")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/europe_visa_jobs/api/app.py
+++ b/src/europe_visa_jobs/api/app.py
@@ -11,11 +11,16 @@ from europe_visa_jobs import __version__
 from europe_visa_jobs.db.repository import Repository
 from europe_visa_jobs.db.session import get_db, init_db
 from europe_visa_jobs.eligibility import CountryRulesRegistry
+from europe_visa_jobs.intelligence.ranking import JobRecommendation, RankingEngine
 from europe_visa_jobs.schemas import (
+    CandidateCreate,
+    CandidateRead,
     CompanyRead,
     EligibilityStatus,
     JobDetailRead,
     JobRead,
+    JobRecommendationRead,
+    RecommendationExplanationRead,
     StatsRead,
 )
 
@@ -86,6 +91,96 @@ def list_companies(
 @app.get("/api/v1/stats", response_model=StatsRead)
 def stats(session: SessionDep) -> StatsRead:
     return StatsRead.model_validate(Repository(session).stats())
+
+
+def _recommendation_read(item: JobRecommendation) -> JobRecommendationRead:
+    match = item.match
+    return JobRecommendationRead(
+        job_id=item.job.id,
+        total_score=item.total_score,
+        visa_score=round(match.visa_score * 100, 2),
+        skill_score=round(match.skill_score, 2),
+        skill_match=round(match.skill_score / 100, 4),
+        experience_score=round(match.experience_score, 2),
+        country_score=round(match.country_score * 100, 2),
+        company_score=round(match.company_score, 2),
+        required_skill_coverage=round(match.required_skill_coverage, 4),
+        preferred_skill_coverage=round(match.preferred_skill_coverage, 4),
+        seniority_match=round(match.seniority_match, 4),
+        role_similarity=round(match.role_similarity, 4),
+        matched_skills=match.matched_skills,
+        missing_skills=match.missing_skills,
+        missing_preferred_skills=match.missing_preferred_skills,
+        reasons=match.reasons,
+        warnings=match.warnings,
+        explanation=[*match.reasons, *match.warnings],
+        job=JobRead.model_validate(item.job),
+    )
+
+
+@app.post("/api/v1/candidates", response_model=CandidateRead, status_code=201)
+@app.post("/candidates", response_model=CandidateRead, status_code=201, include_in_schema=False)
+def create_candidate(candidate: CandidateCreate, session: SessionDep) -> CandidateRead:
+    item = Repository(session).create_candidate(candidate)
+    session.commit()
+    return CandidateRead.model_validate(item)
+
+
+@app.get("/api/v1/candidates/{candidate_id}", response_model=CandidateRead)
+@app.get("/candidates/{candidate_id}", response_model=CandidateRead, include_in_schema=False)
+def get_candidate(candidate_id: int, session: SessionDep) -> CandidateRead:
+    item = Repository(session).get_candidate(candidate_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    return CandidateRead.model_validate(item)
+
+
+def _recommendations(
+    candidate_id: int,
+    session: Session,
+    *,
+    limit: int,
+    include_unknown: bool,
+) -> list[JobRecommendationRead]:
+    repo = Repository(session)
+    candidate = repo.get_candidate(candidate_id)
+    if candidate is None:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    engine = RankingEngine()
+    jobs = repo.list_recommendation_jobs(include_unknown=include_unknown)
+    return [_recommendation_read(item) for item in engine.recommend(candidate, jobs, limit=limit)]
+
+
+@app.get("/api/v1/recommendations/{candidate_id}", response_model=list[JobRecommendationRead])
+@app.get("/recommendations/{candidate_id}", response_model=list[JobRecommendationRead], include_in_schema=False)
+def recommendations(
+    candidate_id: int,
+    session: SessionDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    include_unknown: bool = False,
+) -> list[JobRecommendationRead]:
+    return _recommendations(candidate_id, session, limit=limit, include_unknown=include_unknown)
+
+
+@app.get("/api/v1/recommendations/{candidate_id}/explain", response_model=RecommendationExplanationRead)
+@app.get("/recommendations/{candidate_id}/explain", response_model=RecommendationExplanationRead, include_in_schema=False)
+def explain_recommendations(
+    candidate_id: int,
+    session: SessionDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    include_unknown: bool = False,
+) -> RecommendationExplanationRead:
+    repo = Repository(session)
+    candidate = repo.get_candidate(candidate_id)
+    if candidate is None:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    engine = RankingEngine()
+    recommendations = engine.recommend(candidate, repo.list_recommendation_jobs(include_unknown=include_unknown), limit=limit)
+    return RecommendationExplanationRead(
+        candidate=CandidateRead.model_validate(candidate),
+        weights=engine.config.as_dict(),
+        recommendations=[_recommendation_read(item) for item in recommendations],
+    )
 
 
 def run() -> None:  # pragma: no cover

--- a/src/europe_visa_jobs/api/app.py
+++ b/src/europe_visa_jobs/api/app.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import Annotated
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
 from europe_visa_jobs import __version__
@@ -21,6 +21,7 @@ from europe_visa_jobs.schemas import (
     JobRead,
     JobRecommendationRead,
     RecommendationExplanationRead,
+    RecommendationScoresRead,
     StatsRead,
 )
 
@@ -56,14 +57,16 @@ def list_jobs(
     session: SessionDep,
     country: str | None = None,
     status: EligibilityStatus | None = EligibilityStatus.ELIGIBLE,
+    visa_status: EligibilityStatus | None = None,
     job_family: str | None = None,
+    category: str | None = None,
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> list[JobRead]:
     jobs = Repository(session).list_jobs(
         country=country,
-        status=status,
-        job_family=job_family,
+        status=visa_status if visa_status is not None else status,
+        job_family=job_family or category,
         limit=limit,
         offset=offset,
     )
@@ -97,6 +100,14 @@ def _recommendation_read(item: JobRecommendation) -> JobRecommendationRead:
     match = item.match
     return JobRecommendationRead(
         job_id=item.job.id,
+        scores=RecommendationScoresRead(
+            overall=item.total_score,
+            visa=round(match.visa_score * 100, 2),
+            skill=round(match.skill_score, 2),
+            experience=round(match.experience_score, 2),
+            country=round(match.country_score * 100, 2),
+            company=round(match.company_score, 2),
+        ),
         total_score=item.total_score,
         visa_score=round(match.visa_score * 100, 2),
         skill_score=round(match.skill_score, 2),
@@ -135,20 +146,29 @@ def get_candidate(candidate_id: int, session: SessionDep) -> CandidateRead:
     return CandidateRead.model_validate(item)
 
 
-def _recommendations(
+def _rank_recommendations(
     candidate_id: int,
     session: Session,
     *,
     limit: int,
+    offset: int,
+    country: str | None,
+    role: str | None,
+    min_score: float,
     include_unknown: bool,
-) -> list[JobRecommendationRead]:
+) -> tuple[list[JobRecommendation], int]:
     repo = Repository(session)
     candidate = repo.get_candidate(candidate_id)
     if candidate is None:
         raise HTTPException(status_code=404, detail="Candidate not found")
     engine = RankingEngine()
-    jobs = repo.list_recommendation_jobs(include_unknown=include_unknown)
-    return [_recommendation_read(item) for item in engine.recommend(candidate, jobs, limit=limit)]
+    jobs = repo.list_recommendation_jobs(
+        include_unknown=include_unknown,
+        country=country,
+        role=role,
+    )
+    ranked = [item for item in engine.recommend(candidate, jobs, limit=500) if item.total_score >= min_score]
+    return ranked[offset : offset + limit], len(ranked)
 
 
 @app.get("/api/v1/recommendations/{candidate_id}", response_model=list[JobRecommendationRead])
@@ -156,10 +176,26 @@ def _recommendations(
 def recommendations(
     candidate_id: int,
     session: SessionDep,
+    response: Response,
     limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    country: str | None = None,
+    role: str | None = None,
+    min_score: float = Query(default=0, ge=0, le=100),
     include_unknown: bool = False,
 ) -> list[JobRecommendationRead]:
-    return _recommendations(candidate_id, session, limit=limit, include_unknown=include_unknown)
+    ranked, total = _rank_recommendations(
+        candidate_id,
+        session,
+        limit=limit,
+        offset=offset,
+        country=country,
+        role=role,
+        min_score=min_score,
+        include_unknown=include_unknown,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    return [_recommendation_read(item) for item in ranked]
 
 
 @app.get("/api/v1/recommendations/{candidate_id}/explain", response_model=RecommendationExplanationRead)
@@ -167,7 +203,12 @@ def recommendations(
 def explain_recommendations(
     candidate_id: int,
     session: SessionDep,
+    response: Response,
     limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    country: str | None = None,
+    role: str | None = None,
+    min_score: float = Query(default=0, ge=0, le=100),
     include_unknown: bool = False,
 ) -> RecommendationExplanationRead:
     repo = Repository(session)
@@ -175,11 +216,21 @@ def explain_recommendations(
     if candidate is None:
         raise HTTPException(status_code=404, detail="Candidate not found")
     engine = RankingEngine()
-    recommendations = engine.recommend(candidate, repo.list_recommendation_jobs(include_unknown=include_unknown), limit=limit)
+    ranked, total = _rank_recommendations(
+        candidate_id,
+        session,
+        limit=limit,
+        offset=offset,
+        country=country,
+        role=role,
+        min_score=min_score,
+        include_unknown=include_unknown,
+    )
+    response.headers["X-Total-Count"] = str(total)
     return RecommendationExplanationRead(
         candidate=CandidateRead.model_validate(candidate),
         weights=engine.config.as_dict(),
-        recommendations=[_recommendation_read(item) for item in recommendations],
+        recommendations=[_recommendation_read(item) for item in ranked],
     )
 
 

--- a/src/europe_visa_jobs/connectors/base.py
+++ b/src/europe_visa_jobs/connectors/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import httpx
 
@@ -20,7 +21,7 @@ class BaseConnector(ABC):
     async def fetch_jobs(self) -> list[NormalizedJob]:
         raise NotImplementedError
 
-    async def _get(self, url: str, **kwargs: object) -> httpx.Response:
+    async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
         try:
             response = await self.client.get(url, **kwargs)
             response.raise_for_status()

--- a/src/europe_visa_jobs/db/models.py
+++ b/src/europe_visa_jobs/db/models.py
@@ -2,12 +2,41 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
     pass
+
+
+class Candidate(Base):
+    __tablename__ = "candidates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_roles: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    years_of_experience: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    seniority: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    preferred_countries: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    visa_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    relocation_preference: Mapped[str] = mapped_column(String(30), default="preferred", nullable=False)
+    remote_preference: Mapped[str] = mapped_column(String(30), default="no_preference", nullable=False)
+    excluded_locations: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False)
 
 
 class Company(Base):
@@ -65,6 +94,10 @@ class Job(Base):
     job_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     job_family: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    required_skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    preferred_skills: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    min_experience_years: Mapped[float | None] = mapped_column(Float, nullable=True)
+    seniority: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
     eligibility_status: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
     eligibility_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     first_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False)

--- a/src/europe_visa_jobs/db/repository.py
+++ b/src/europe_visa_jobs/db/repository.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
-from europe_visa_jobs.db.models import Company, Job, JobEvidence, SponsorRecord
+from europe_visa_jobs.db.models import Candidate, Company, Job, JobEvidence, SponsorRecord
+from europe_visa_jobs.intelligence.job_profile import analyze_job
+from europe_visa_jobs.intelligence.ontology import SkillOntology
 from europe_visa_jobs.schemas import (
+    CandidateCreate,
     CompanySponsorEvidence,
     EligibilityAssessment,
     EligibilityStatus,
     NormalizedJob,
 )
-from europe_visa_jobs.utils import normalize_company_name
+from europe_visa_jobs.utils import normalize_company_name, normalize_country
 
 
 class Repository:
@@ -61,6 +64,7 @@ class Repository:
             career_url=career_url,
             sponsor_verified=sponsor is not None,
         )
+        profile = analyze_job(normalized_job.title, normalized_job.description, normalized_job.job_family)
         stmt = select(Job).where(
             Job.provider == normalized_job.provider.value,
             Job.source_slug == normalized_job.source_slug,
@@ -85,6 +89,10 @@ class Repository:
                 job_url=normalized_job.job_url,
                 posted_at=normalized_job.posted_at,
                 job_family=normalized_job.job_family.value,
+                required_skills=profile.required_skills,
+                preferred_skills=profile.preferred_skills,
+                min_experience_years=profile.min_experience_years,
+                seniority=profile.seniority.value if profile.seniority else None,
                 eligibility_status=assessment.status.value,
                 eligibility_score=assessment.score,
             )
@@ -104,6 +112,10 @@ class Repository:
             job.job_url = normalized_job.job_url
             job.posted_at = normalized_job.posted_at
             job.job_family = normalized_job.job_family.value
+            job.required_skills = profile.required_skills
+            job.preferred_skills = profile.preferred_skills
+            job.min_experience_years = profile.min_experience_years
+            job.seniority = profile.seniority.value if profile.seniority else None
             job.eligibility_status = assessment.status.value
             job.eligibility_score = assessment.score
             job.last_seen_at = datetime.now(UTC)
@@ -160,8 +172,42 @@ class Repository:
         stmt = stmt.order_by(Job.posted_at.desc().nullslast(), Job.id.desc()).limit(limit).offset(offset)
         return list(self.session.scalars(stmt))
 
+    def list_recommendation_jobs(self, *, include_unknown: bool = False, limit: int = 500) -> list[Job]:
+        statuses = [EligibilityStatus.ELIGIBLE.value]
+        if include_unknown:
+            statuses.append(EligibilityStatus.UNKNOWN.value)
+        stmt = (
+            select(Job)
+            .options(joinedload(Job.company), joinedload(Job.evidence))
+            .where(Job.active.is_(True), Job.eligibility_status.in_(statuses))
+            .order_by(Job.posted_at.desc().nullslast(), Job.id.desc())
+            .limit(limit)
+        )
+        return list(self.session.scalars(stmt).unique())
+
     def get_job(self, job_id: int) -> Job | None:
         return self.session.get(Job, job_id)
+
+    def create_candidate(self, candidate: CandidateCreate) -> Candidate:
+        ontology = SkillOntology()
+        item = Candidate(
+            name=candidate.name,
+            target_roles=list(dict.fromkeys(candidate.target_roles)),
+            skills=ontology.normalize_skills(candidate.skills),
+            years_of_experience=candidate.years_of_experience,
+            seniority=candidate.seniority.value if candidate.seniority else None,
+            preferred_countries=list(dict.fromkeys(normalize_country(country) for country in candidate.preferred_countries)),
+            visa_required=candidate.visa_required,
+            relocation_preference=candidate.relocation_preference.value,
+            remote_preference=candidate.remote_preference.value,
+            excluded_locations=list(dict.fromkeys(item.strip() for item in candidate.excluded_locations)),
+        )
+        self.session.add(item)
+        self.session.flush()
+        return item
+
+    def get_candidate(self, candidate_id: int) -> Candidate | None:
+        return self.session.get(Candidate, candidate_id)
 
     def list_companies(self, *, country: str | None = None, limit: int = 100) -> list[Company]:
         stmt = select(Company)

--- a/src/europe_visa_jobs/db/repository.py
+++ b/src/europe_visa_jobs/db/repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, joinedload
 
 from europe_visa_jobs.db.models import Candidate, Company, Job, JobEvidence, SponsorRecord
@@ -13,9 +13,10 @@ from europe_visa_jobs.schemas import (
     CompanySponsorEvidence,
     EligibilityAssessment,
     EligibilityStatus,
+    JobFamily,
     NormalizedJob,
 )
-from europe_visa_jobs.utils import normalize_company_name, normalize_country
+from europe_visa_jobs.utils import classify_role, normalize_company_name, normalize_country
 
 
 class Repository:
@@ -172,7 +173,14 @@ class Repository:
         stmt = stmt.order_by(Job.posted_at.desc().nullslast(), Job.id.desc()).limit(limit).offset(offset)
         return list(self.session.scalars(stmt))
 
-    def list_recommendation_jobs(self, *, include_unknown: bool = False, limit: int = 500) -> list[Job]:
+    def list_recommendation_jobs(
+        self,
+        *,
+        include_unknown: bool = False,
+        limit: int = 500,
+        country: str | None = None,
+        role: str | None = None,
+    ) -> list[Job]:
         statuses = [EligibilityStatus.ELIGIBLE.value]
         if include_unknown:
             statuses.append(EligibilityStatus.UNKNOWN.value)
@@ -180,9 +188,19 @@ class Repository:
             select(Job)
             .options(joinedload(Job.company), joinedload(Job.evidence))
             .where(Job.active.is_(True), Job.eligibility_status.in_(statuses))
-            .order_by(Job.posted_at.desc().nullslast(), Job.id.desc())
-            .limit(limit)
         )
+        if country:
+            stmt = stmt.where(Job.country == country)
+        if role:
+            try:
+                family = JobFamily(role)
+            except ValueError:
+                family = classify_role(role)
+            if family is not JobFamily.OTHER:
+                stmt = stmt.where(Job.job_family == family.value)
+            else:
+                stmt = stmt.where(or_(Job.title.ilike(f"%{role}%"), Job.job_family == role))
+        stmt = stmt.order_by(Job.posted_at.desc().nullslast(), Job.id.desc()).limit(limit)
         return list(self.session.scalars(stmt).unique())
 
     def get_job(self, job_id: int) -> Job | None:
@@ -208,6 +226,9 @@ class Repository:
 
     def get_candidate(self, candidate_id: int) -> Candidate | None:
         return self.session.get(Candidate, candidate_id)
+
+    def get_candidate_by_name(self, name: str) -> Candidate | None:
+        return self.session.scalar(select(Candidate).where(Candidate.name == name))
 
     def list_companies(self, *, country: str | None = None, limit: int = 100) -> list[Company]:
         stmt = select(Company)

--- a/src/europe_visa_jobs/intelligence/__init__.py
+++ b/src/europe_visa_jobs/intelligence/__init__.py
@@ -1,0 +1,8 @@
+"""Deterministic candidate and job intelligence services."""
+
+from europe_visa_jobs.intelligence.matching import CandidateMatcher
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+from europe_visa_jobs.intelligence.profile_parser import CandidateProfileParser
+from europe_visa_jobs.intelligence.ranking import RankingConfig, RankingEngine
+
+__all__ = ["CandidateMatcher", "CandidateProfileParser", "RankingConfig", "RankingEngine", "SkillOntology"]

--- a/src/europe_visa_jobs/intelligence/__init__.py
+++ b/src/europe_visa_jobs/intelligence/__init__.py
@@ -3,6 +3,13 @@
 from europe_visa_jobs.intelligence.matching import CandidateMatcher
 from europe_visa_jobs.intelligence.ontology import SkillOntology
 from europe_visa_jobs.intelligence.profile_parser import CandidateProfileParser
-from europe_visa_jobs.intelligence.ranking import RankingConfig, RankingEngine
+from europe_visa_jobs.intelligence.ranking import RankingConfig, RankingEngine, load_ranking_config
 
-__all__ = ["CandidateMatcher", "CandidateProfileParser", "RankingConfig", "RankingEngine", "SkillOntology"]
+__all__ = [
+    "CandidateMatcher",
+    "CandidateProfileParser",
+    "RankingConfig",
+    "RankingEngine",
+    "SkillOntology",
+    "load_ranking_config",
+]

--- a/src/europe_visa_jobs/intelligence/company.py
+++ b/src/europe_visa_jobs/intelligence/company.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from europe_visa_jobs.db.models import Company, Job
+
+
+@dataclass(frozen=True)
+class CompanyIntelligence:
+    score: float
+    positive_signals: list[str]
+    negative_signals: list[str]
+
+
+class CompanyIntelligenceScorer:
+    """Scores sponsor friendliness from persisted Phase-1 company and job evidence."""
+
+    POSITIVE: ClassVar[dict[str, tuple[int, str]]] = {
+        "verified_sponsor_registry": (45, "Recognized sponsor evidence is on file."),
+        "relocation_support": (15, "Relocation support is mentioned."),
+        "relocation_provided": (15, "The employer says relocation is provided."),
+        "international_candidates": (15, "International candidates are welcomed."),
+        "apply_from_abroad": (15, "Applications from abroad are accepted."),
+        "visa_sponsorship": (10, "The vacancy explicitly mentions visa sponsorship."),
+        "sponsor_work_visa": (10, "The employer explicitly mentions sponsoring a work visa."),
+        "work_permit_support": (10, "Work-permit support is mentioned."),
+        "immigration_support": (10, "Immigration support is mentioned."),
+    }
+    NEGATIVE: ClassVar[dict[str, tuple[int, str]]] = {
+        "no_sponsorship": (-55, "The vacancy says sponsorship is unavailable."),
+        "no_sponsorship_direct": (-55, "The vacancy says sponsorship is unavailable."),
+        "without_sponsorship": (-45, "Existing work authorization without sponsorship is required."),
+        "existing_work_rights": (-45, "Existing local work rights are required."),
+        "eu_eea_only": (-45, "The vacancy is restricted to EU/EEA candidates."),
+        "local_candidates_only": (-45, "The vacancy is limited to local or regional residents."),
+        "citizenship_required": (-45, "The vacancy requires a specific citizenship."),
+    }
+
+    def score(self, company: Company, job: Job) -> CompanyIntelligence:
+        score = 25.0
+        positive: list[str] = []
+        negative: list[str] = []
+        if company.sponsor_verified:
+            score += 45
+            positive.append("Recognized sponsor evidence is on file.")
+
+        seen: set[str] = set()
+        for evidence in job.evidence:
+            if evidence.code in seen:
+                continue
+            seen.add(evidence.code)
+            if evidence.code == "verified_sponsor_registry" and company.sponsor_verified:
+                continue
+            if evidence.code in self.POSITIVE:
+                points, message = self.POSITIVE[evidence.code]
+                score += points
+                positive.append(message)
+            elif evidence.code in self.NEGATIVE:
+                points, message = self.NEGATIVE[evidence.code]
+                score += points
+                negative.append(message)
+        return CompanyIntelligence(max(0.0, min(100.0, score)), positive, negative)

--- a/src/europe_visa_jobs/intelligence/job_profile.py
+++ b/src/europe_visa_jobs/intelligence/job_profile.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+from europe_visa_jobs.schemas import JobFamily, SeniorityLevel
+from europe_visa_jobs.utils.roles import classify_role
+
+
+@dataclass(frozen=True)
+class JobProfile:
+    required_skills: list[str]
+    preferred_skills: list[str]
+    min_experience_years: float | None
+    seniority: SeniorityLevel | None
+    job_family: JobFamily
+
+
+_SENIORITY_PATTERNS: tuple[tuple[SeniorityLevel, tuple[str, ...]], ...] = (
+    (SeniorityLevel.PRINCIPAL, (r"\bprincipal\b",)),
+    (SeniorityLevel.STAFF, (r"\bstaff\b",)),
+    (SeniorityLevel.LEAD, (r"\blead\b", r"\bhead of\b")),
+    (SeniorityLevel.DIRECTOR, (r"\bdirector\b",)),
+    (SeniorityLevel.SENIOR, (r"\bsenior\b", r"\bsr\.?\b")),
+    (SeniorityLevel.MID, (r"\bmid[- ]level\b", r"\bmid[- ]senior\b")),
+    (SeniorityLevel.JUNIOR, (r"\bjunior\b", r"\bjr\.?\b", r"\bentry[- ]level\b")),
+    (SeniorityLevel.INTERN, (r"\bintern(ship)?\b",)),
+)
+
+
+def infer_seniority(text: str) -> SeniorityLevel | None:
+    for level, patterns in _SENIORITY_PATTERNS:
+        if any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns):
+            return level
+    return None
+
+
+def infer_min_experience(text: str) -> float | None:
+    patterns = (
+        r"(?:at least|minimum of|min\.?|more than)\s+(\d+(?:\.\d+)?)\s*\+?\s*years?",
+        r"(\d+(?:\.\d+)?)\s*\+?\s*years?\s+(?:of\s+)?experience",
+        r"experience\s+of\s+(\d+(?:\.\d+)?)\s*\+?\s*years?",
+    )
+    values = [float(match.group(1)) for pattern in patterns for match in re.finditer(pattern, text, re.IGNORECASE)]
+    return max(values) if values else None
+
+
+def analyze_job(title: str, description: str, job_family: JobFamily | str | None = None, *, ontology: SkillOntology | None = None) -> JobProfile:
+    ontology = ontology or SkillOntology()
+    full_text = f"{title}\n{description}"
+    all_skills = ontology.extract(full_text)
+    preferred_text = " ".join(
+        sentence
+        for sentence in re.split(r"(?<=[.!?])\s+|\n+", description)
+        if re.search(r"\b(?:nice to have|preferred|bonus|plus|desirable|ideally)\b", sentence, re.IGNORECASE)
+    )
+    preferred = ontology.extract(preferred_text)
+    preferred_keys = {skill.casefold() for skill in preferred}
+    required = [skill for skill in all_skills if skill.casefold() not in preferred_keys]
+    family = JobFamily(job_family) if job_family else classify_role(title)
+    return JobProfile(required, preferred, infer_min_experience(full_text), infer_seniority(title), family)

--- a/src/europe_visa_jobs/intelligence/matching.py
+++ b/src/europe_visa_jobs/intelligence/matching.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from europe_visa_jobs.db.models import Candidate, Job
+from europe_visa_jobs.intelligence.company import CompanyIntelligenceScorer
+from europe_visa_jobs.intelligence.job_profile import JobProfile, analyze_job
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+from europe_visa_jobs.schemas import EligibilityStatus, JobFamily, PreferenceLevel, SeniorityLevel
+from europe_visa_jobs.utils.countries import normalize_country
+from europe_visa_jobs.utils.roles import classify_role
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    visa_score: float
+    skill_score: float
+    experience_score: float
+    country_score: float
+    company_score: float
+    required_skill_coverage: float
+    preferred_skill_coverage: float
+    seniority_match: float
+    role_similarity: float
+    matched_skills: list[str]
+    missing_skills: list[str]
+    missing_preferred_skills: list[str]
+    reasons: list[str]
+    warnings: list[str]
+    company_positive_signals: list[str]
+    company_negative_signals: list[str]
+    profile: JobProfile
+
+
+_LEVEL_ORDER = {
+    SeniorityLevel.INTERN: 0,
+    SeniorityLevel.JUNIOR: 1,
+    SeniorityLevel.MID: 2,
+    SeniorityLevel.SENIOR: 3,
+    SeniorityLevel.STAFF: 4,
+    SeniorityLevel.LEAD: 4,
+    SeniorityLevel.PRINCIPAL: 5,
+    SeniorityLevel.DIRECTOR: 6,
+}
+
+
+class CandidateMatcher:
+    def __init__(self, ontology: SkillOntology | None = None, company_scorer: CompanyIntelligenceScorer | None = None) -> None:
+        self.ontology = ontology or SkillOntology()
+        self.company_scorer = company_scorer or CompanyIntelligenceScorer()
+
+    def match(self, candidate: Candidate, job: Job) -> MatchResult:
+        profile = analyze_job(job.title, job.description, job.job_family, ontology=self.ontology)
+        # Persisted intelligence is authoritative when available, while old Phase-1 rows remain
+        # fully matchable through the deterministic analyzer.
+        if job.required_skills or job.preferred_skills or job.min_experience_years is not None or job.seniority:
+            profile = JobProfile(list(job.required_skills), list(job.preferred_skills), job.min_experience_years, SeniorityLevel(job.seniority) if job.seniority else profile.seniority, profile.job_family)
+
+        candidate_skills = {skill.casefold(): skill for skill in self.ontology.normalize_skills(candidate.skills)}
+        required = self.ontology.normalize_skills(profile.required_skills)
+        preferred = self.ontology.normalize_skills(profile.preferred_skills)
+        matched_required = [skill for skill in required if skill.casefold() in candidate_skills]
+        matched_preferred = [skill for skill in preferred if skill.casefold() in candidate_skills]
+        missing = [skill for skill in required if skill.casefold() not in candidate_skills]
+        missing_preferred = [skill for skill in preferred if skill.casefold() not in candidate_skills]
+        required_coverage = self._coverage(len(matched_required), len(required))
+        preferred_coverage = self._coverage(len(matched_preferred), len(preferred))
+        skill_score = 100 * (0.7 * required_coverage + 0.3 * preferred_coverage)
+
+        seniority_match = self._seniority_match(candidate.seniority, profile.seniority)
+        experience_score = self._experience_match(candidate.years_of_experience, profile.min_experience_years, seniority_match)
+        role_similarity = self._role_similarity(candidate.target_roles, job.title, profile.job_family)
+        country_score, country_reasons, country_warnings = self._country_match(candidate, job)
+        visa_score, visa_reasons, visa_warnings = self._visa_match(candidate, job)
+        company = self.company_scorer.score(job.company, job)
+
+        reasons = list(country_reasons) + list(visa_reasons) + list(company.positive_signals)
+        warnings = list(country_warnings) + list(visa_warnings) + list(company.negative_signals)
+        if matched_required:
+            reasons.append(f"Matched required skills: {', '.join(matched_required)}.")
+        if missing:
+            warnings.append(f"Missing required skills: {', '.join(missing)}.")
+        if role_similarity >= 0.9:
+            reasons.append("The role aligns with the candidate's target role family.")
+        elif role_similarity < 0.5:
+            warnings.append("The role is outside the candidate's target role family.")
+        if seniority_match >= 0.9:
+            reasons.append("The role seniority matches the candidate profile.")
+        elif profile.seniority:
+            warnings.append("The role seniority differs from the candidate profile.")
+
+        return MatchResult(
+            visa_score=visa_score,
+            skill_score=skill_score,
+            experience_score=experience_score,
+            country_score=country_score,
+            company_score=company.score,
+            required_skill_coverage=required_coverage,
+            preferred_skill_coverage=preferred_coverage,
+            seniority_match=seniority_match,
+            role_similarity=role_similarity,
+            matched_skills=matched_required + matched_preferred,
+            missing_skills=missing,
+            missing_preferred_skills=missing_preferred,
+            reasons=self._unique(reasons),
+            warnings=self._unique(warnings),
+            company_positive_signals=company.positive_signals,
+            company_negative_signals=company.negative_signals,
+            profile=profile,
+        )
+
+    @staticmethod
+    def _coverage(matched: int, total: int) -> float:
+        return matched / total if total else 1.0
+
+    @staticmethod
+    def _seniority_match(candidate_level: SeniorityLevel | str | None, job_level: SeniorityLevel | None) -> float:
+        if not candidate_level or not job_level:
+            return 1.0
+        candidate = SeniorityLevel(candidate_level)
+        distance = abs(_LEVEL_ORDER[candidate] - _LEVEL_ORDER[job_level])
+        return {0: 1.0, 1: 0.8, 2: 0.5}.get(distance, 0.25)
+
+    @staticmethod
+    def _experience_match(years: float, minimum: float | None, seniority_match: float) -> float:
+        years_score = 1.0 if not minimum else min(1.0, years / minimum)
+        return 100 * (0.7 * years_score + 0.3 * seniority_match)
+
+    @staticmethod
+    def _role_similarity(target_roles: list[str], title: str, family: JobFamily) -> float:
+        if not target_roles:
+            return 0.5
+        title_lower = title.casefold()
+        target_families = [classify_role(role) for role in target_roles]
+        if family in target_families and family is not JobFamily.OTHER:
+            return 1.0
+        if any(role.casefold() in title_lower or title_lower in role.casefold() for role in target_roles):
+            return 0.85
+        return 0.2
+
+    @staticmethod
+    def _country_match(candidate: Candidate, job: Job) -> tuple[float, list[str], list[str]]:
+        country = normalize_country(job.country) if job.country else None
+        location = job.location.casefold()
+        excluded = [value.casefold() for value in candidate.excluded_locations]
+        if any(value in location or value == (country or "").casefold() for value in excluded):
+            return 0.0, [], ["The job location is excluded by the candidate."]
+        preferred = {normalize_country(value).casefold() for value in candidate.preferred_countries}
+        country_score = 1.0 if country and country.casefold() in preferred else (0.65 if not preferred else 0.35)
+        reasons = [f"The job is in preferred country {country}."] if country and country.casefold() in preferred else []
+        warnings = [] if reasons or not preferred else [f"The job country {country or 'unknown'} is not in the preferred countries."]
+
+        workplace = (job.workplace_type or "").casefold()
+        is_remote = "remote" in workplace or "remote" in location
+        if candidate.remote_preference == PreferenceLevel.REQUIRED and not is_remote:
+            return 0.0, reasons, [*warnings, "The candidate requires remote work."]
+        if candidate.remote_preference == PreferenceLevel.PREFERRED and is_remote:
+            country_score = min(1.0, country_score + 0.1)
+            reasons.append("Remote work matches the candidate preference.")
+        if candidate.relocation_preference == PreferenceLevel.REQUIRED and country and country.casefold() not in preferred:
+            warnings.append("Relocation is required but this country is not preferred.")
+        return min(1.0, country_score), reasons, warnings
+
+    @staticmethod
+    def _visa_match(candidate: Candidate, job: Job) -> tuple[float, list[str], list[str]]:
+        status = EligibilityStatus(job.eligibility_status) if job.eligibility_status else EligibilityStatus.UNKNOWN
+        if candidate.visa_required:
+            if status is EligibilityStatus.ELIGIBLE:
+                return 1.0, ["The job passed the strict sponsorship eligibility gate."], []
+            if status is EligibilityStatus.UNKNOWN:
+                return 0.25, [], ["Sponsorship evidence is incomplete for a candidate who needs a visa."]
+            return 0.0, [], ["The job failed the sponsorship eligibility gate."]
+        if status is EligibilityStatus.REJECTED:
+            return 0.25, [], ["The vacancy contains a work-authorization restriction."]
+        return 1.0, ["The candidate does not require sponsorship."], []
+
+    @staticmethod
+    def _unique(values: list[str]) -> list[str]:
+        return list(dict.fromkeys(values))

--- a/src/europe_visa_jobs/intelligence/ontology.py
+++ b/src/europe_visa_jobs/intelligence/ontology.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
 
 
 @dataclass(frozen=True)
@@ -68,11 +72,16 @@ def _pattern(alias: str) -> re.Pattern[str]:
 class SkillOntology:
     """Curated canonical skills with deterministic alias normalization and extraction."""
 
-    def __init__(self, definitions: tuple[SkillDefinition, ...] = _SKILLS) -> None:
-        self._definitions = definitions
-        self._by_canonical = {item.canonical_name.casefold(): item for item in definitions}
+    def __init__(
+        self,
+        definitions: tuple[SkillDefinition, ...] | None = None,
+        data_path: str | Path | None = None,
+    ) -> None:
+        loaded_definitions = definitions if definitions is not None else _load_definitions(data_path)
+        self._definitions = loaded_definitions
+        self._by_canonical = {item.canonical_name.casefold(): item for item in loaded_definitions}
         self._aliases: list[tuple[SkillDefinition, re.Pattern[str]]] = []
-        for definition in definitions:
+        for definition in loaded_definitions:
             for alias in sorted({definition.canonical_name, *definition.aliases}, key=len, reverse=True):
                 self._aliases.append((definition, _pattern(alias)))
 
@@ -114,3 +123,24 @@ class SkillOntology:
     def category(self, canonical_name: str) -> str | None:
         definition = self._by_canonical.get(canonical_name.casefold())
         return definition.category if definition else None
+
+
+def _load_definitions(data_path: str | Path | None = None) -> tuple[SkillDefinition, ...]:
+    path = Path(data_path) if data_path else Path(__file__).resolve().parents[3] / "data" / "skills.yaml"
+    if not path.is_file():
+        return _SKILLS
+    try:
+        payload: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+        rows = payload.get("skills", []) if isinstance(payload, dict) else []
+        definitions = tuple(
+            SkillDefinition(
+                canonical_name=str(row["canonical"]),
+                category=str((row.get("categories") or [row.get("category", "other")])[0]),
+                aliases=tuple(str(alias) for alias in row.get("aliases", [])),
+            )
+            for row in rows
+            if isinstance(row, dict) and row.get("canonical")
+        )
+        return definitions or _SKILLS
+    except (OSError, TypeError, KeyError, IndexError, yaml.YAMLError):
+        return _SKILLS

--- a/src/europe_visa_jobs/intelligence/ontology.py
+++ b/src/europe_visa_jobs/intelligence/ontology.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SkillDefinition:
+    canonical_name: str
+    category: str
+    aliases: tuple[str, ...]
+
+
+# This is intentionally a small, curated ontology rather than an opaque model. It is easy to
+# review, extend, and regression-test. Aliases are ordered longest-first at runtime to prevent
+# a short alias from consuming part of a longer phrase.
+_SKILLS: tuple[SkillDefinition, ...] = (
+    SkillDefinition("Python", "programming", ("python", "python3", "python programming")),
+    SkillDefinition("Java", "programming", ("java",)),
+    SkillDefinition("JavaScript", "programming", ("javascript", "java script", "js")),
+    SkillDefinition("TypeScript", "programming", ("typescript", "type script", "ts")),
+    SkillDefinition("Go", "programming", ("golang", "go language")),
+    SkillDefinition("Rust", "programming", ("rust programming",)),
+    SkillDefinition("C++", "programming", ("c++", "cpp")),
+    SkillDefinition("SQL", "data", ("sql", "structured query language")),
+    SkillDefinition("PyTorch", "machine_learning", ("pytorch", "torch", "pytorch framework")),
+    SkillDefinition("TensorFlow", "machine_learning", ("tensorflow", "tensor flow")),
+    SkillDefinition("scikit-learn", "machine_learning", ("scikit-learn", "sklearn", "scikit learn")),
+    SkillDefinition("LLM", "machine_learning", ("llm", "large language model", "large language models", "generative ai", "genai", "generative artificial intelligence")),
+    SkillDefinition("RAG", "machine_learning", ("rag", "retrieval augmented generation", "retrieval-augmented generation")),
+    SkillDefinition("Natural Language Processing", "machine_learning", ("nlp", "natural language processing")),
+    SkillDefinition("Computer Vision", "machine_learning", ("computer vision", "cv models")),
+    SkillDefinition("MLflow", "machine_learning", ("mlflow", "ml flow")),
+    SkillDefinition("Kubernetes", "cloud", ("kubernetes", "k8s")),
+    SkillDefinition("Docker", "cloud", ("docker", "docker containers")),
+    SkillDefinition("AWS", "cloud", ("aws", "amazon web services")),
+    SkillDefinition("Azure", "cloud", ("azure", "microsoft azure")),
+    SkillDefinition("Google Cloud", "cloud", ("google cloud", "gcp")),
+    SkillDefinition("Terraform", "cloud", ("terraform",)),
+    SkillDefinition("CI/CD", "devops", ("ci/cd", "cicd", "continuous integration", "continuous delivery")),
+    SkillDefinition("Linux", "infrastructure", ("linux",)),
+    SkillDefinition("Git", "tools", ("git", "git version control")),
+    SkillDefinition("React", "frontend", ("react", "react.js", "reactjs")),
+    SkillDefinition("Vue.js", "frontend", ("vue", "vue.js", "vuejs")),
+    SkillDefinition("Angular", "frontend", ("angular",)),
+    SkillDefinition("Node.js", "backend", ("node", "node.js", "nodejs")),
+    SkillDefinition("Django", "backend", ("django",)),
+    SkillDefinition("FastAPI", "backend", ("fastapi", "fast api")),
+    SkillDefinition("Spring", "backend", ("spring boot", "spring framework")),
+    SkillDefinition("PostgreSQL", "databases", ("postgresql", "postgres", "postgre sql")),
+    SkillDefinition("Redis", "databases", ("redis",)),
+    SkillDefinition("Kafka", "data", ("kafka", "apache kafka")),
+    SkillDefinition("Spark", "data", ("spark", "apache spark", "pyspark")),
+    SkillDefinition("Airflow", "data", ("airflow", "apache airflow")),
+    SkillDefinition("dbt", "data", ("dbt", "data build tool")),
+    SkillDefinition("Prometheus", "observability", ("prometheus",)),
+    SkillDefinition("Grafana", "observability", ("grafana",)),
+)
+
+
+def _pattern(alias: str) -> re.Pattern[str]:
+    escaped = re.escape(alias.casefold()).replace(r"\ ", r"\s+")
+    # Word boundaries do not work well for C++, .NET, or slash-separated names. A conservative
+    # alphanumeric boundary avoids matching skills embedded inside unrelated words.
+    return re.compile(rf"(?<![a-z0-9]){escaped}(?![a-z0-9])", re.IGNORECASE)
+
+
+class SkillOntology:
+    """Curated canonical skills with deterministic alias normalization and extraction."""
+
+    def __init__(self, definitions: tuple[SkillDefinition, ...] = _SKILLS) -> None:
+        self._definitions = definitions
+        self._by_canonical = {item.canonical_name.casefold(): item for item in definitions}
+        self._aliases: list[tuple[SkillDefinition, re.Pattern[str]]] = []
+        for definition in definitions:
+            for alias in sorted({definition.canonical_name, *definition.aliases}, key=len, reverse=True):
+                self._aliases.append((definition, _pattern(alias)))
+
+    def definitions(self) -> tuple[SkillDefinition, ...]:
+        return self._definitions
+
+    def normalize_skill(self, value: str) -> str:
+        cleaned = re.sub(r"\s+", " ", value.strip()).casefold()
+        definition = self._by_canonical.get(cleaned)
+        if definition:
+            return definition.canonical_name
+        for candidate, pattern in self._aliases:
+            if pattern.fullmatch(cleaned):
+                return candidate.canonical_name
+        return value.strip()
+
+    def normalize_skills(self, values: list[str] | tuple[str, ...]) -> list[str]:
+        result: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            if not isinstance(value, str) or not value.strip():
+                continue
+            canonical = self.normalize_skill(value)
+            key = canonical.casefold()
+            if key not in seen:
+                result.append(canonical)
+                seen.add(key)
+        return result
+
+    def extract(self, text: str) -> list[str]:
+        found: list[str] = []
+        seen: set[str] = set()
+        for definition, pattern in self._aliases:
+            if pattern.search(text) and definition.canonical_name.casefold() not in seen:
+                found.append(definition.canonical_name)
+                seen.add(definition.canonical_name.casefold())
+        return found
+
+    def category(self, canonical_name: str) -> str | None:
+        definition = self._by_canonical.get(canonical_name.casefold())
+        return definition.category if definition else None

--- a/src/europe_visa_jobs/intelligence/profile_parser.py
+++ b/src/europe_visa_jobs/intelligence/profile_parser.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+
+from europe_visa_jobs.intelligence.job_profile import infer_min_experience, infer_seniority
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+from europe_visa_jobs.schemas import CandidateCreate
+from europe_visa_jobs.utils.countries import COUNTRY_ALIASES, infer_country
+from europe_visa_jobs.utils.roles import classify_role
+
+
+class CandidateProfileParser:
+    """Extracts a conservative candidate profile from plain text without an LLM."""
+
+    def __init__(self, ontology: SkillOntology | None = None) -> None:
+        self.ontology = ontology or SkillOntology()
+
+    def parse(self, text: str, *, name: str) -> CandidateCreate:
+        roles = self._roles(text)
+        countries = self._countries(text)
+        years = infer_min_experience(text) or 0
+        return CandidateCreate(
+            name=name,
+            target_roles=roles or ["Software Engineer"],
+            skills=self.ontology.extract(text),
+            years_of_experience=min(years, 60),
+            seniority=infer_seniority(text),
+            preferred_countries=countries,
+            visa_required=True,
+        )
+
+    @staticmethod
+    def _roles(text: str) -> list[str]:
+        roles: list[str] = []
+        for line in text.splitlines():
+            cleaned = re.sub(r"^[\s•*-]*(?:title|role|position)\s*:\s*", "", line, flags=re.IGNORECASE).strip()
+            if cleaned and classify_role(cleaned).value != "other" and len(cleaned) <= 100:
+                roles.append(cleaned)
+        return list(dict.fromkeys(roles))
+
+    @staticmethod
+    def _countries(text: str) -> list[str]:
+        found: list[str] = []
+        for country, aliases in COUNTRY_ALIASES.items():
+            if any(re.search(rf"(?<![\w]){re.escape(alias)}(?![\w])", text, re.IGNORECASE) for alias in aliases):
+                found.append(country)
+        return found or ([infer_country(text)] if infer_country(text) else [])

--- a/src/europe_visa_jobs/intelligence/profile_parser.py
+++ b/src/europe_visa_jobs/intelligence/profile_parser.py
@@ -44,4 +44,7 @@ class CandidateProfileParser:
         for country, aliases in COUNTRY_ALIASES.items():
             if any(re.search(rf"(?<![\w]){re.escape(alias)}(?![\w])", text, re.IGNORECASE) for alias in aliases):
                 found.append(country)
-        return found or ([infer_country(text)] if infer_country(text) else [])
+        if found:
+            return found
+        inferred = infer_country(text)
+        return [inferred] if inferred else []

--- a/src/europe_visa_jobs/intelligence/ranking.py
+++ b/src/europe_visa_jobs/intelligence/ranking.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
 
 from europe_visa_jobs.db.models import Candidate, Job
 from europe_visa_jobs.intelligence.matching import CandidateMatcher, MatchResult
@@ -22,6 +26,34 @@ class RankingConfig:
     def as_dict(self) -> dict[str, float]:
         return {"visa": self.visa, "skill": self.skill, "experience": self.experience, "country": self.country, "company": self.company}
 
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> RankingConfig:
+        payload: Any = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("ranking configuration must be a YAML mapping")
+
+        def weight(name: str) -> float:
+            key = f"{name}_score"
+            item = payload.get(key)
+            if not isinstance(item, dict) or "weight" not in item:
+                raise ValueError(f"ranking configuration is missing {key}.weight")
+            return float(item["weight"])
+
+        return cls(
+            visa=weight("visa"),
+            skill=weight("skill"),
+            experience=weight("experience"),
+            country=weight("country"),
+            company=weight("company"),
+        )
+
+
+def load_ranking_config(path: str | Path | None = None) -> RankingConfig:
+    config_path = Path(path) if path else Path(__file__).resolve().parents[3] / "config" / "ranking.yaml"
+    if not config_path.is_file():
+        return RankingConfig()
+    return RankingConfig.from_yaml(config_path)
+
 
 @dataclass(frozen=True)
 class JobRecommendation:
@@ -31,8 +63,13 @@ class JobRecommendation:
 
 
 class RankingEngine:
-    def __init__(self, config: RankingConfig | None = None, matcher: CandidateMatcher | None = None) -> None:
-        self.config = config or RankingConfig()
+    def __init__(
+        self,
+        config: RankingConfig | None = None,
+        matcher: CandidateMatcher | None = None,
+        config_path: str | Path | None = None,
+    ) -> None:
+        self.config = config or load_ranking_config(config_path)
         self.matcher = matcher or CandidateMatcher()
 
     def recommend(self, candidate: Candidate, jobs: list[Job], *, limit: int = 100) -> list[JobRecommendation]:

--- a/src/europe_visa_jobs/intelligence/ranking.py
+++ b/src/europe_visa_jobs/intelligence/ranking.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from europe_visa_jobs.db.models import Candidate, Job
+from europe_visa_jobs.intelligence.matching import CandidateMatcher, MatchResult
+
+
+@dataclass(frozen=True)
+class RankingConfig:
+    visa: float = 0.35
+    skill: float = 0.30
+    experience: float = 0.15
+    country: float = 0.10
+    company: float = 0.10
+
+    def __post_init__(self) -> None:
+        weights = (self.visa, self.skill, self.experience, self.country, self.company)
+        if any(weight < 0 for weight in weights) or abs(sum(weights) - 1.0) > 1e-9:
+            raise ValueError("ranking weights must be non-negative and sum to 1")
+
+    def as_dict(self) -> dict[str, float]:
+        return {"visa": self.visa, "skill": self.skill, "experience": self.experience, "country": self.country, "company": self.company}
+
+
+@dataclass(frozen=True)
+class JobRecommendation:
+    job: Job
+    total_score: float
+    match: MatchResult
+
+
+class RankingEngine:
+    def __init__(self, config: RankingConfig | None = None, matcher: CandidateMatcher | None = None) -> None:
+        self.config = config or RankingConfig()
+        self.matcher = matcher or CandidateMatcher()
+
+    def recommend(self, candidate: Candidate, jobs: list[Job], *, limit: int = 100) -> list[JobRecommendation]:
+        ranked = [self.score(candidate, job) for job in jobs]
+        ranked.sort(key=lambda item: (-item.total_score, -(item.job.posted_at.timestamp() if item.job.posted_at else 0), item.job.id))
+        return ranked[:limit]
+
+    def score(self, candidate: Candidate, job: Job) -> JobRecommendation:
+        match = self.matcher.match(candidate, job)
+        total = (
+            self.config.visa * match.visa_score
+            + self.config.skill * match.skill_score
+            + self.config.experience * match.experience_score
+            + self.config.country * (match.country_score * 100)
+            + self.config.company * match.company_score
+        )
+        return JobRecommendation(job=job, total_score=round(total, 2), match=match)

--- a/src/europe_visa_jobs/schemas.py
+++ b/src/europe_visa_jobs/schemas.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ATSProvider(StrEnum):
@@ -44,6 +44,23 @@ class JobFamily(StrEnum):
     OTHER = "other"
 
 
+class SeniorityLevel(StrEnum):
+    INTERN = "intern"
+    JUNIOR = "junior"
+    MID = "mid"
+    SENIOR = "senior"
+    STAFF = "staff"
+    LEAD = "lead"
+    PRINCIPAL = "principal"
+    DIRECTOR = "director"
+
+
+class PreferenceLevel(StrEnum):
+    REQUIRED = "required"
+    PREFERRED = "preferred"
+    NO_PREFERENCE = "no_preference"
+
+
 class SourceConfig(BaseModel):
     provider: ATSProvider
     company_name: str = Field(min_length=1)
@@ -73,6 +90,50 @@ class NormalizedJob(BaseModel):
     raw: dict[str, Any] = Field(default_factory=dict, repr=False)
 
     model_config = ConfigDict(use_enum_values=False)
+
+
+class CandidateCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    target_roles: list[str] = Field(min_length=1, max_length=20)
+    skills: list[str] = Field(default_factory=list, max_length=100)
+    years_of_experience: float = Field(default=0, ge=0, le=60)
+    seniority: SeniorityLevel | None = None
+    preferred_countries: list[str] = Field(default_factory=list, max_length=30)
+    visa_required: bool = True
+    relocation_preference: PreferenceLevel = PreferenceLevel.PREFERRED
+    remote_preference: PreferenceLevel = PreferenceLevel.NO_PREFERENCE
+    excluded_locations: list[str] = Field(default_factory=list, max_length=50)
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def clean_name(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("target_roles", "skills", "preferred_countries", "excluded_locations", mode="before")
+    @classmethod
+    def clean_list(cls, value: object) -> object:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return value
+        return [item.strip() if isinstance(item, str) else item for item in value]
+
+    @field_validator("target_roles", "skills", "preferred_countries", "excluded_locations")
+    @classmethod
+    def reject_empty_items(cls, value: list[object]) -> list[object]:
+        if any(isinstance(item, str) and not item for item in value):
+            raise ValueError("list items must not be empty")
+        return value
+
+
+class CandidateRead(CandidateCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Evidence(BaseModel):
@@ -129,6 +190,10 @@ class JobRead(BaseModel):
     job_url: str | None
     posted_at: datetime | None
     job_family: JobFamily
+    required_skills: list[str] = Field(default_factory=list)
+    preferred_skills: list[str] = Field(default_factory=list)
+    min_experience_years: float | None = None
+    seniority: SeniorityLevel | None = None
     eligibility_status: EligibilityStatus | None = None
     eligibility_score: int | None = None
 
@@ -167,3 +232,31 @@ class StatsRead(BaseModel):
     rejected_jobs: int
     unknown_jobs: int
     companies: int
+
+
+class JobRecommendationRead(BaseModel):
+    job_id: int
+    total_score: float = Field(ge=0, le=100)
+    visa_score: float = Field(ge=0, le=100)
+    skill_score: float = Field(ge=0, le=100)
+    skill_match: float = Field(ge=0, le=1)
+    experience_score: float = Field(ge=0, le=100)
+    country_score: float = Field(ge=0, le=100)
+    company_score: float = Field(ge=0, le=100)
+    required_skill_coverage: float = Field(ge=0, le=1)
+    preferred_skill_coverage: float = Field(ge=0, le=1)
+    seniority_match: float = Field(ge=0, le=1)
+    role_similarity: float = Field(ge=0, le=1)
+    matched_skills: list[str] = Field(default_factory=list)
+    missing_skills: list[str] = Field(default_factory=list)
+    missing_preferred_skills: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    explanation: list[str] = Field(default_factory=list)
+    job: JobRead
+
+
+class RecommendationExplanationRead(BaseModel):
+    candidate: CandidateRead
+    weights: dict[str, float]
+    recommendations: list[JobRecommendationRead]

--- a/src/europe_visa_jobs/schemas.py
+++ b/src/europe_visa_jobs/schemas.py
@@ -234,8 +234,20 @@ class StatsRead(BaseModel):
     companies: int
 
 
+class RecommendationScoresRead(BaseModel):
+    """Grouped scores for frontend clients; flat score fields remain for compatibility."""
+
+    overall: float = Field(ge=0, le=100)
+    visa: float = Field(ge=0, le=100)
+    skill: float = Field(ge=0, le=100)
+    experience: float = Field(ge=0, le=100)
+    country: float = Field(ge=0, le=100)
+    company: float = Field(ge=0, le=100)
+
+
 class JobRecommendationRead(BaseModel):
     job_id: int
+    scores: RecommendationScoresRead
     total_score: float = Field(ge=0, le=100)
     visa_score: float = Field(ge=0, le=100)
     skill_score: float = Field(ge=0, le=100)

--- a/src/europe_visa_jobs/utils/__init__.py
+++ b/src/europe_visa_jobs/utils/__init__.py
@@ -1,4 +1,4 @@
-from europe_visa_jobs.utils.countries import infer_country
+from europe_visa_jobs.utils.countries import infer_country, normalize_country
 from europe_visa_jobs.utils.roles import classify_role, is_supported_tech_role
 from europe_visa_jobs.utils.text import html_to_text, normalize_company_name, normalize_whitespace
 
@@ -8,5 +8,6 @@ __all__ = [
     "infer_country",
     "is_supported_tech_role",
     "normalize_company_name",
+    "normalize_country",
     "normalize_whitespace",
 ]

--- a/src/europe_visa_jobs/utils/countries.py
+++ b/src/europe_visa_jobs/utils/countries.py
@@ -58,3 +58,12 @@ def infer_country(location: str | None, default: str | None = None) -> str | Non
         if city in lowered:
             return country
     return default
+
+
+def normalize_country(value: str) -> str:
+    """Return the canonical country label when a known alias is supplied."""
+    cleaned = re.sub(r"\s+", " ", value.strip()).casefold()
+    for country, aliases in COUNTRY_ALIASES.items():
+        if cleaned == country.casefold() or cleaned in {alias.casefold() for alias in aliases}:
+            return country
+    return value.strip()

--- a/src/europe_visa_jobs/utils/roles.py
+++ b/src/europe_visa_jobs/utils/roles.py
@@ -6,7 +6,7 @@ from europe_visa_jobs.schemas import JobFamily
 
 ROLE_RULES: tuple[tuple[JobFamily, tuple[str, ...]], ...] = (
     (JobFamily.MLOPS, (r"\bmlops\b", r"machine learning platform", r"ml platform")),
-    (JobFamily.AI_ML, (r"machine learning", r"\bai engineer", r"artificial intelligence", r"\bnlp\b", r"computer vision", r"applied scientist", r"\bllm\b")),
+    (JobFamily.AI_ML, (r"machine learning", r"\bml engineer", r"\bai engineer", r"artificial intelligence", r"\bnlp\b", r"computer vision", r"applied scientist", r"\bllm\b")),
     (JobFamily.DATA_ENGINEERING, (r"data engineer", r"analytics engineer", r"data platform")),
     (JobFamily.DATA_SCIENCE, (r"data scientist", r"decision scientist")),
     (JobFamily.FRONTEND, (r"front[ -]?end", r"frontend", r"react developer", r"ui engineer")),

--- a/tests/fixtures/phase2_candidate.json
+++ b/tests/fixtures/phase2_candidate.json
@@ -1,0 +1,12 @@
+{
+  "name": "Senior ML Engineer",
+  "target_roles": ["Machine Learning Engineer", "AI Engineer"],
+  "skills": ["python3", "Torch", "GenAI", "RAG", "K8s", "MLflow"],
+  "years_of_experience": 7,
+  "seniority": "senior",
+  "preferred_countries": ["Germany", "Netherlands", "Sweden"],
+  "visa_required": true,
+  "relocation_preference": "preferred",
+  "remote_preference": "no_preference",
+  "excluded_locations": ["United Kingdom"]
+}

--- a/tests/fixtures/phase2_expected_ranking.json
+++ b/tests/fixtures/phase2_expected_ranking.json
@@ -1,0 +1,3 @@
+{
+  "top_external_ids": ["ai-de", "backend-de", "frontend-se"]
+}

--- a/tests/fixtures/phase2_jobs.json
+++ b/tests/fixtures/phase2_jobs.json
@@ -1,0 +1,29 @@
+[
+  {
+    "external_id": "ai-de",
+    "company_name": "Global AI GmbH",
+    "title": "Senior Machine Learning Engineer",
+    "description": "Visa sponsorship and relocation support are available. Required skills: Python, PyTorch, Kubernetes. Nice to have: MLflow.",
+    "location": "Berlin, Germany",
+    "country": "Germany",
+    "apply_url": "https://example.com/ai-de"
+  },
+  {
+    "external_id": "backend-de",
+    "company_name": "Backend Systems GmbH",
+    "title": "Senior Backend Engineer",
+    "description": "Visa sponsorship is available. Required skills: Python, PostgreSQL, Docker.",
+    "location": "Munich, Germany",
+    "country": "Germany",
+    "apply_url": "https://example.com/backend-de"
+  },
+  {
+    "external_id": "frontend-se",
+    "company_name": "Nordic Web AB",
+    "title": "Frontend Engineer",
+    "description": "Visa sponsorship is available. Required skills: JavaScript, React, CSS.",
+    "location": "Stockholm, Sweden",
+    "country": "Sweden",
+    "apply_url": "https://example.com/frontend-se"
+  }
+]

--- a/tests/test_phase2_api.py
+++ b/tests/test_phase2_api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from europe_visa_jobs.api.app import app
+from europe_visa_jobs.db.repository import Repository
+from europe_visa_jobs.db.session import get_db
+from europe_visa_jobs.eligibility import EligibilityEngine
+from europe_visa_jobs.schemas import ATSProvider, NormalizedJob
+
+
+def test_candidate_and_recommendation_endpoints(session_factory):
+    with session_factory() as session:
+        job = NormalizedJob(
+            external_id="api-job",
+            provider=ATSProvider.GREENHOUSE,
+            source_slug="api-fixture",
+            company_name="API Company",
+            title="AI Engineer",
+            description="Visa sponsorship and relocation support are available. Required skills: Python, PyTorch.",
+            location="Berlin, Germany",
+            country="Germany",
+            apply_url="https://example.com/api-job",
+        )
+        Repository(session).upsert_job(job, EligibilityEngine().assess(job))
+        session.commit()
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    client = TestClient(app)
+    payload = {
+        "name": "API Candidate",
+        "target_roles": ["AI Engineer"],
+        "skills": ["python3", "torch"],
+        "years_of_experience": 5,
+        "seniority": "senior",
+        "preferred_countries": ["Germany"],
+        "visa_required": True,
+    }
+    try:
+        created = client.post("/api/v1/candidates", json=payload)
+        assert created.status_code == 201
+        candidate = created.json()
+        assert candidate["skills"] == ["Python", "PyTorch"]
+        assert client.get(f"/api/v1/candidates/{candidate['id']}").status_code == 200
+
+        recommendations = client.get(f"/api/v1/recommendations/{candidate['id']}")
+        assert recommendations.status_code == 200
+        assert recommendations.json()[0]["job"]["title"] == "AI Engineer"
+        assert recommendations.json()[0]["reasons"]
+
+        explanation = client.get(f"/api/v1/recommendations/{candidate['id']}/explain")
+        assert explanation.status_code == 200
+        assert explanation.json()["weights"]["visa"] == 0.35
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_phase2_hardening.py
+++ b/tests/test_phase2_hardening.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from europe_visa_jobs.api.app import app
+from europe_visa_jobs.db.models import Candidate, Job
+from europe_visa_jobs.db.repository import Repository
+from europe_visa_jobs.db.session import get_db
+from europe_visa_jobs.eligibility import EligibilityEngine
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+from europe_visa_jobs.intelligence.ranking import RankingConfig, RankingEngine, load_ranking_config
+from europe_visa_jobs.schemas import ATSProvider, CandidateCreate, NormalizedJob
+from europe_visa_jobs.utils import classify_role
+from scripts.seed_demo import seed_demo
+
+
+def test_ranking_configuration_is_loaded_from_yaml(tmp_path: Path):
+    config_path = tmp_path / "ranking.yaml"
+    config_path.write_text(
+        """visa_score:\n  weight: 0.40\nskill_score:\n  weight: 0.25\nexperience_score:\n  weight: 0.15\ncountry_score:\n  weight: 0.10\ncompany_score:\n  weight: 0.10\n""",
+        encoding="utf-8",
+    )
+    config = RankingConfig.from_yaml(config_path)
+    assert config.as_dict() == {
+        "visa": 0.4,
+        "skill": 0.25,
+        "experience": 0.15,
+        "country": 0.1,
+        "company": 0.1,
+    }
+    assert load_ranking_config().as_dict() == RankingEngine().config.as_dict()
+
+
+def test_invalid_ranking_configuration_is_rejected(tmp_path: Path):
+    config_path = tmp_path / "ranking.yaml"
+    config_path.write_text(
+        """visa_score:\n  weight: 0.9\nskill_score:\n  weight: 0\nexperience_score:\n  weight: 0\ncountry_score:\n  weight: 0\ncompany_score:\n  weight: 0\n""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="sum to 1"):
+        RankingConfig.from_yaml(config_path)
+
+
+def test_skill_ontology_uses_the_reviewable_data_file():
+    ontology = SkillOntology()
+    assert ontology.category("PyTorch") == "machine_learning"
+    assert {item.canonical_name for item in ontology.definitions()} >= {"Python", "PyTorch", "LLM"}
+
+
+def test_demo_seed_is_fictional_and_idempotent(db_session):
+    assert seed_demo(db_session) == (3, 3)
+    assert seed_demo(db_session) == (3, 0)
+    assert db_session.query(Job).count() == 3
+    assert db_session.query(Candidate).count() == 3
+    assert all("DEMO SAMPLE DATA ONLY" in job.description for job in db_session.query(Job).all())
+
+
+def test_recommendation_pagination_filters_and_structured_scores(session_factory):
+    with session_factory() as session:
+        repo = Repository(session)
+        jobs = (
+            ("ai", "AI Engineer", "Berlin, Germany", "Germany", "Python, PyTorch"),
+            ("backend", "Backend Engineer", "Stockholm, Sweden", "Sweden", "Python, PostgreSQL"),
+        )
+        for external_id, title, location, country, skills in jobs:
+            job = NormalizedJob(
+                external_id=external_id,
+                provider=ATSProvider.GREENHOUSE,
+                source_slug="hardening",
+                company_name=f"Demo {external_id}",
+                title=title,
+                description=f"Visa sponsorship is available. Required skills: {skills}.",
+                location=location,
+                country=country,
+                apply_url=f"https://example.invalid/{external_id}",
+                job_family=classify_role(title),
+            )
+            repo.upsert_job(job, EligibilityEngine().assess(job))
+        candidate = repo.create_candidate(
+            CandidateCreate(
+                name="Hardening Candidate",
+                target_roles=["AI Engineer"],
+                skills=["Python", "PyTorch"],
+                years_of_experience=5,
+                preferred_countries=["Germany", "Sweden"],
+            )
+        )
+        session.commit()
+        candidate_id = candidate.id
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    client = TestClient(app)
+    try:
+        page = client.get(f"/api/v1/recommendations/{candidate_id}", params={"limit": 1, "offset": 1})
+        assert page.status_code == 200
+        assert page.headers["x-total-count"] == "2"
+        assert len(page.json()) == 1
+        assert "scores" in page.json()[0]
+        assert page.json()[0]["scores"]["overall"] == page.json()[0]["total_score"]
+
+        all_items = client.get(f"/api/v1/recommendations/{candidate_id}").json()
+        best_score = max(item["total_score"] for item in all_items)
+        high_score = client.get(
+            f"/api/v1/recommendations/{candidate_id}",
+            params={"min_score": best_score},
+        )
+        assert len(high_score.json()) == 1
+
+        role = client.get(f"/api/v1/recommendations/{candidate_id}", params={"role": "AI Engineer"})
+        assert [item["job"]["title"] for item in role.json()] == ["AI Engineer"]
+
+        country = client.get(f"/api/v1/recommendations/{candidate_id}", params={"country": "Sweden"})
+        assert [item["job"]["country"] for item in country.json()] == ["Sweden"]
+
+        jobs = client.get("/api/v1/jobs", params={"category": "ai_ml", "visa_status": "eligible"})
+        assert jobs.status_code == 200
+        assert [item["title"] for item in jobs.json()] == ["AI Engineer"]
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_phase2_matching.py
+++ b/tests/test_phase2_matching.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from europe_visa_jobs.db.repository import Repository
+from europe_visa_jobs.eligibility import EligibilityEngine
+from europe_visa_jobs.intelligence.ranking import RankingEngine
+from europe_visa_jobs.schemas import ATSProvider, CandidateCreate, NormalizedJob
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_candidate_is_normalized_and_ranked_explainably(db_session):
+    candidate_data = json.loads((FIXTURES / "phase2_candidate.json").read_text(encoding="utf-8"))
+    job_rows = json.loads((FIXTURES / "phase2_jobs.json").read_text(encoding="utf-8"))
+    expected = json.loads((FIXTURES / "phase2_expected_ranking.json").read_text(encoding="utf-8"))
+    repo = Repository(db_session)
+    candidate = repo.create_candidate(CandidateCreate.model_validate(candidate_data))
+
+    for row in job_rows:
+        normalized = NormalizedJob(
+            external_id=row["external_id"],
+            provider=ATSProvider.GREENHOUSE,
+            source_slug="phase2-fixture",
+            company_name=row["company_name"],
+            title=row["title"],
+            description=row["description"],
+            location=row["location"],
+            country=row["country"],
+            apply_url=row["apply_url"],
+        )
+        repo.upsert_job(normalized, EligibilityEngine().assess(normalized))
+    db_session.commit()
+
+    recommendations = RankingEngine().recommend(candidate, repo.list_recommendation_jobs())
+    assert [item.job.external_id for item in recommendations] == expected["top_external_ids"]
+    top = recommendations[0]
+    assert top.match.required_skill_coverage == 1
+    assert set(top.match.matched_skills) >= {"Python", "PyTorch", "Kubernetes"}
+    assert top.match.missing_skills == []
+    assert top.match.visa_score == 1
+    assert top.match.reasons
+
+
+def test_excluded_location_and_missing_skills_are_warnings(db_session):
+    repo = Repository(db_session)
+    candidate = repo.create_candidate(
+        CandidateCreate(
+            name="Candidate",
+            target_roles=["Backend Engineer"],
+            skills=["Python"],
+            years_of_experience=2,
+            preferred_countries=["Germany"],
+            excluded_locations=["Berlin"],
+        )
+    )
+    normalized = NormalizedJob(
+        external_id="warning",
+        provider=ATSProvider.GREENHOUSE,
+        source_slug="phase2-fixture",
+        company_name="Acme",
+        title="Senior Backend Engineer",
+        description="Visa sponsorship is available. Required skills: Python, Kubernetes.",
+        location="Berlin, Germany",
+        country="Germany",
+        apply_url="https://example.com/warning",
+    )
+    repo.upsert_job(normalized, EligibilityEngine().assess(normalized))
+    db_session.commit()
+    recommendation = RankingEngine().recommend(candidate, repo.list_recommendation_jobs())[0]
+    assert recommendation.match.country_score == 0
+    assert "Kubernetes" in recommendation.match.missing_skills
+    assert any("excluded" in warning for warning in recommendation.match.warnings)

--- a/tests/test_phase2_ontology.py
+++ b/tests/test_phase2_ontology.py
@@ -1,0 +1,23 @@
+from europe_visa_jobs.intelligence.ontology import SkillOntology
+
+
+def test_skill_aliases_normalize_to_canonical_names():
+    ontology = SkillOntology()
+    assert ontology.normalize_skills(["python3", "Torch", "GenAI", "k8s", "ML flow"]) == [
+        "Python",
+        "PyTorch",
+        "LLM",
+        "Kubernetes",
+        "MLflow",
+    ]
+
+
+def test_skill_extraction_is_deterministic_and_deduplicated():
+    ontology = SkillOntology()
+    assert ontology.extract("Experience with Torch and GenAI. Also used PyTorch.") == ["PyTorch", "LLM"]
+
+
+def test_skill_categories_are_available():
+    ontology = SkillOntology()
+    assert ontology.category("PyTorch") == "machine_learning"
+    assert ontology.category("unknown") is None

--- a/tests/test_phase2_profile_parser.py
+++ b/tests/test_phase2_profile_parser.py
@@ -1,0 +1,19 @@
+from europe_visa_jobs.intelligence.profile_parser import CandidateProfileParser
+
+
+def test_profile_parser_extracts_roles_skills_experience_and_countries():
+    profile = CandidateProfileParser().parse(
+        "Role: Senior AI Engineer\n7 years of experience with Python, Torch and GenAI.\nOpen to Germany or Sweden.",
+        name="Candidate",
+    )
+    assert profile.target_roles == ["Senior AI Engineer"]
+    assert profile.skills == ["Python", "PyTorch", "LLM"]
+    assert profile.years_of_experience == 7
+    assert profile.preferred_countries == ["Germany", "Sweden"]
+
+
+def test_profile_parser_uses_safe_defaults_when_text_is_sparse():
+    profile = CandidateProfileParser().parse("Curious builder", name="Candidate")
+    assert profile.target_roles == ["Software Engineer"]
+    assert profile.skills == []
+    assert profile.visa_required is True


### PR DESCRIPTION
Hardens the deterministic Phase 2 backend for Phase 3 UI consumption.

Implemented:
- Frontend-friendly grouped recommendation scores while preserving flat response fields.
- Recommendation country/role/minimum-score filters, limit/offset pagination, and X-Total-Count.
- Jobs category and visa_status filter aliases with backward compatibility.
- File-backed ranking weights in config/ranking.yaml.
- File-backed skill ontology in data/skills.yaml with a safe code fallback.
- Idempotent fictional demo seed script and validation tests.
- Docker image copies runtime config/data assets.
- CI lint/type-checks scripts and builds the Docker image.
- README and Phase 2 contract/demo documentation updates.

Validation:
- GitHub Actions run 32496480289 passed on Python 3.11 and 3.12.
- 41 tests passed on both CI matrix jobs.
- Coverage 90.16% (85% gate).
- Ruff and mypy passed.
- Alembic upgrade/downgrade passed.
- Docker image build passed on both CI matrix jobs.
- Demo seed ran twice deterministically.

Demo data is explicitly fictional and makes no real sponsorship claims.