### PR TITLE
Hotfix Windows launcher GUI startup for v1.0.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tailwindcss/postcss": "^4.1.17",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "@tailwindcss/postcss": "^4.1.17",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -14,6 +14,7 @@ import webbrowser
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -290,6 +291,8 @@ class RuntimeServices:
 
 
 def smoke_test(data_dir: Path) -> int:
+    from europe_visa_jobs import __version__
+
     services = RuntimeServices(data_dir)
     try:
         migrate_database()
@@ -307,7 +310,7 @@ def smoke_test(data_dir: Path) -> int:
             seed_smoke_data()
         services.start()
         health = read_json(f"{API_URL}/health")
-        if health.get("status") != "ok" or health.get("version") != "1.0.0":
+        if health.get("status") != "ok" or health.get("version") != __version__:
             raise RuntimeError(f"Unexpected API health response: {health!r}")
         jobs = read_json(f"{API_URL}/api/v1/jobs?limit=1")
         if not isinstance(jobs, list):
@@ -372,9 +375,9 @@ class LauncherWindow:
         threading.Thread(target=self._start_runtime, daemon=True, name="career-radar-startup").start()
         self.root.mainloop()
 
-    def _ui(self, callback, *args) -> None:
+    def _ui(self, callback, *args, **kwargs) -> None:
         with suppress(self.tk.TclError):
-            self.root.after(0, callback, *args)
+            self.root.after(0, partial(callback, *args, **kwargs))
 
     def _set_status(self, text: str) -> None:
         self.status.set(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "1.0.0"
+version = "1.0.1"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/tests/test_windows_launcher.py
+++ b/tests/test_windows_launcher.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def load_launcher_module():
+    path = Path(__file__).resolve().parents[1] / "packaging" / "windows" / "launcher.py"
+    spec = importlib.util.spec_from_file_location("career_radar_windows_launcher", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeTclError(Exception):
+    pass
+
+
+class FakeRoot:
+    def after(self, delay_ms: int, callback):
+        assert delay_ms == 0
+        callback()
+
+
+def test_ui_dispatch_accepts_keyword_arguments() -> None:
+    launcher = load_launcher_module()
+    window = object.__new__(launcher.LauncherWindow)
+    window.tk = SimpleNamespace(TclError=FakeTclError)
+    window.root = FakeRoot()
+
+    observed: dict[str, str] = {}
+
+    def configure(*, state: str) -> None:
+        observed["state"] = state
+
+    window._ui(configure, state="normal")
+
+    assert observed == {"state": "normal"}


### PR DESCRIPTION
## v1.0.1 Windows launcher hotfix

Fixes the real-user startup failure reported from the released Windows installer:

`LauncherWindow._ui() got an unexpected keyword argument 'state'`

### Changes
- make the Tk UI dispatch helper accept and safely schedule keyword arguments
- use the package `__version__` in the packaged runtime smoke test instead of a hard-coded release version
- add a focused regression test reproducing the `state="normal"` callback path
- bump backend/web release metadata to `1.0.1`

### Release criteria
Do not merge until the exact hotfix head passes both the full CI workflow and the Windows desktop package workflow, including clean installed and portable smoke tests without host Python/Node.