### PR TITLE
Release correction: harden packaged runtime provenance

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/windows-package.yml"
   push:
     branches: [main]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -48,6 +49,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" pyinstaller
+
+      - name: Assert packaging imports the checked-out source
+        shell: pwsh
+        run: |
+          $expected = (Resolve-Path "src/europe_visa_jobs").Path
+          $actual = (python -c "import europe_visa_jobs; print(europe_visa_jobs.__path__[0])").Trim()
+          if ((Resolve-Path $actual).Path -ne $expected) {
+            throw "Packaging imported $actual instead of checked-out source $expected"
+          }
+          $version = (python -c "import europe_visa_jobs; print(europe_visa_jobs.__version__)").Trim()
+          if ($version -ne "1.0.0") { throw "Unexpected packaged backend version: $version" }
 
       - name: Install and build web production bundle
         shell: pwsh
@@ -232,7 +244,7 @@ jobs:
           }
 
   publish-release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build-windows
     runs-on: ubuntu-latest
     permissions:

--- a/migrations/versions/0004_runtime_compatibility.py
+++ b/migrations/versions/0004_runtime_compatibility.py
@@ -1,0 +1,30 @@
+"""Add nullable job deduplication columns used by newer packaged runtimes.
+
+This keeps upgrades from the v1.0.0 Phase 4 schema forward-compatible with
+runtime code that can normalize apply URLs and identify cross-source copies.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0004_runtime_compatibility"
+down_revision: Union[str, None] = "0003_candidate_job_tracking"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("canonical_apply_url", sa.String(length=1000), nullable=True))
+    op.add_column("jobs", sa.Column("duplicate_of_job_id", sa.Integer(), nullable=True))
+    op.create_index("ix_jobs_canonical_apply_url", "jobs", ["canonical_apply_url"], unique=False)
+    op.create_index("ix_jobs_duplicate_of_job_id", "jobs", ["duplicate_of_job_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_duplicate_of_job_id", table_name="jobs")
+    op.drop_index("ix_jobs_canonical_apply_url", table_name="jobs")
+    op.drop_column("jobs", "duplicate_of_job_id")
+    op.drop_column("jobs", "canonical_apply_url")

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -231,6 +231,15 @@ class RuntimeServices:
             self.api_thread = threading.Thread(target=self._run_api, daemon=True, name="career-radar-api")
             self.api_thread.start()
             wait_for(f"{API_URL}/health", failure=self._api_failure)
+            health = read_json(f"{API_URL}/health")
+            from europe_visa_jobs import __version__
+
+            if health.get("status") != "ok" or health.get("version") != __version__:
+                raise RuntimeError(
+                    "The configured API port is serving an unexpected application: "
+                    f"expected {__version__!r}, received {health!r}. "
+                    "Close the other Career Radar/API process and retry."
+                )
 
             root = install_dir()
             node = root / "runtime" / "node.exe"


### PR DESCRIPTION
Adds the forward-compatible packaged-runtime migration, asserts checked-out source/version before PyInstaller, validates API health version and surfaces port conflicts, and restricts release publishing to version tags after the published v1.0.0 audit found contaminated assets.