### PR TITLE
fix: keep Windows packaging version-consistent on main

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -58,8 +58,11 @@ jobs:
           if ((Resolve-Path $actual).Path -ne $expected) {
             throw "Packaging imported $actual instead of checked-out source $expected"
           }
-          $version = (python -c "import europe_visa_jobs; print(europe_visa_jobs.__version__)").Trim()
-          if ($version -ne "1.0.0") { throw "Unexpected packaged backend version: $version" }
+          $backendVersion = (python -c "import europe_visa_jobs; print(europe_visa_jobs.__version__)").Trim()
+          $webVersion = (Get-Content "apps/web/package.json" | ConvertFrom-Json).version
+          if ($backendVersion -ne $webVersion) {
+            throw "Backend version $backendVersion does not match web version $webVersion"
+          }
 
       - name: Install and build web production bundle
         shell: pwsh

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -316,7 +316,9 @@ def smoke_test(data_dir: Path) -> int:
             seed_smoke_data()
         services.start()
         health = read_json(f"{API_URL}/health")
-        if health.get("status") != "ok" or health.get("version") != "1.0.0":
+        from europe_visa_jobs import __version__
+
+        if health.get("status") != "ok" or health.get("version") != __version__:
             raise RuntimeError(f"Unexpected API health response: {health!r}")
         jobs = read_json(f"{API_URL}/api/v1/jobs?limit=1")
         if not isinstance(jobs, list):


### PR DESCRIPTION
The merged release-correction branch is now at 1c01c95. This follow-up removes the hard-coded 1.0.0 assertion from the reusable Windows workflow and launcher smoke test: backend and web versions must agree, allowing the current main 1.0.1 hotfix to pass while preserving exact v1.0.0 validation on the release-hardening branch.