### PR TITLE
Fix desktop profile save during SQLite refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship or relocation support.
 
-**Career Radar v1.1.0** is a strict, explainable career radar: it collects current technical vacancies, rejects hard work-authorization restrictions, evaluates sponsorship evidence, ranks opportunities against a candidate profile, and explains why a job is—or is not—a realistic target.
+**Career Radar v1.1.1** is a strict, explainable career radar: it collects current technical vacancies, rejects hard work-authorization restrictions, evaluates sponsorship evidence, ranks opportunities against a candidate profile, and explains why a job is—or is not—a realistic target.
 
 It uses **no LLM and no paid AI API at runtime**. Decisions are deterministic, inspectable, reproducible, and backed by stored evidence.
 
@@ -13,7 +13,7 @@ It uses **no LLM and no paid AI API at runtime**. Decisions are deterministic, i
 For most Windows users, no developer setup is needed.
 
 1. Open **GitHub Releases**.
-2. Download the setup file matching the current release version (for example, `CareerRadar-Setup-v1.1.0.exe`).
+2. Download the setup file matching the current release version (for example, `CareerRadar-Setup-v1.1.1.exe`).
 3. Install and launch **Career Radar**.
 
 The Windows package bundles the Python backend runtime, the production Next.js server, a private Node runtime, database migrations, and project configuration. Users do **not** need to install Python, Node.js, npm packages, pip packages, Docker, or PostgreSQL.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "europe-career-radar-web",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,5 +1,5 @@
 #ifndef AppVersion
-  #define AppVersion "1.1.0"
+  #define AppVersion "1.1.1"
 #endif
 #ifndef SourceDir
   #define SourceDir "build\\windows\\app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "1.1.0"
+version = "1.1.1"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/europe_visa_jobs/db/session.py
+++ b/src/europe_visa_jobs/db/session.py
@@ -11,7 +11,10 @@ from europe_visa_jobs.settings import get_settings
 
 def make_engine(database_url: str | None = None) -> Engine:
     url = database_url or get_settings().database_url
-    connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
+    # The desktop launcher can refresh sources in a background thread while
+    # the UI submits a profile or tracking update. Let SQLite wait for the
+    # bounded writer transaction instead of surfacing a transient 500.
+    connect_args = {"check_same_thread": False, "timeout": 60.0} if url.startswith("sqlite") else {}
     return create_engine(url, pool_pre_ping=True, connect_args=connect_args)
 
 

--- a/tests/test_db_locking.py
+++ b/tests/test_db_locking.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 
 import pytest
+from sqlalchemy import text
 
 from europe_visa_jobs.db.locking import _pid_is_running, database_write_lock
+from europe_visa_jobs.db.session import make_engine
 
 
 def test_sqlite_writer_lock_rejects_overlap(tmp_path):
@@ -43,3 +47,37 @@ def test_malformed_writer_lock_is_recovered(tmp_path):
     with database_write_lock(f"sqlite:///{database.as_posix()}"):
         assert lock.exists()
     assert not lock.exists()
+
+
+def test_sqlite_connection_waits_for_a_short_background_refresh_lock(tmp_path):
+    database = tmp_path / "career-radar.db"
+    url = f"sqlite:///{database.as_posix()}"
+    first = make_engine(url)
+    second = make_engine(url)
+    with first.begin() as connection:
+        connection.execute(text("create table writes (value integer not null)"))
+
+    errors: list[BaseException] = []
+    with first.connect() as connection:
+        connection.exec_driver_sql("BEGIN EXCLUSIVE")
+        connection.execute(text("insert into writes values (1)"))
+
+        def write_after_lock_release() -> None:
+            try:
+                with second.begin() as writer:
+                    writer.execute(text("insert into writes values (2)"))
+            except BaseException as error:  # pragma: no cover - assertion below reports it
+                errors.append(error)
+
+        thread = threading.Thread(target=write_after_lock_release)
+        thread.start()
+        time.sleep(0.2)
+        connection.commit()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    with second.connect() as connection:
+        assert connection.scalar(text("select count(*) from writes")) == 2
+    first.dispose()
+    second.dispose()

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -11,8 +11,8 @@ _SPEC.loader.exec_module(validate_release_inputs)
 
 
 def test_release_version_sources_match():
-    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.0"
+    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.1"
 
 
 def test_release_validation_accepts_the_real_snapshot():
-    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.0"
+    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.1"


### PR DESCRIPTION
Fixes a post-release defect found using the published v1.1.0 installer: background refresh could hold SQLite long enough for profile creation to return database locked / 500. SQLite connections now wait up to 60 seconds, with regression coverage. Versioned as v1.1.1; v1.1.0 remains immutable.