### PR TITLE
Fix first-launch profile save during background refresh

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "europe-career-radar-web",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,5 +1,5 @@
 #ifndef AppVersion
-  #define AppVersion "1.1.1"
+  #define AppVersion "1.1.2"
 #endif
 #ifndef SourceDir
   #define SourceDir "build\\windows\\app"

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -160,21 +160,25 @@ def refresh_jobs(data_dir: Path) -> None:
     # The packaged catalog is a safe first-run seed. Once a source has been
     # validated, refreshes use the persistent registry and never regenerate a
     # web-scale discovery pass during desktop startup.
-    with database_write_lock(os.environ["DATABASE_URL"]):
-        with SessionLocal() as session:
-            registry = SourceRegistry(session)
-            import_production_sponsor_evidence(session, sponsor_evidence)
-            if not registry.list_sources():
-                # A release package must include this generated artifact.  It is
-                # validated for 500+ live boards before import, so first launch is
-                # useful without starting a web-scale crawl.
-                for config in load_sources(snapshot, minimum_snapshot_sources=500):
-                    registry.import_verified_snapshot(config)
-                for config in load_sources(sources):
-                    registry.import_config(config.model_copy(update={"manual_override": True}))
-                session.commit()
-            has_verified = bool(registry.list_sources(enabled_only=True, verified_only=True, limit=1))
-        asyncio.run(_ingest(None if has_verified else str(sources), registry_mode=has_verified))
+    # Keep the cross-process lock around the short bootstrap transaction only.
+    # _ingest opens one short DB transaction per source, but performs network
+    # fetches between those transactions. Holding this lock across the entire
+    # first-run refresh made profile saves wait until the full source batch
+    # completed and eventually fail with SQLite's busy timeout.
+    with database_write_lock(os.environ["DATABASE_URL"]), SessionLocal() as session:
+        registry = SourceRegistry(session)
+        import_production_sponsor_evidence(session, sponsor_evidence)
+        if not registry.list_sources():
+            # A release package must include this generated artifact.  It is
+            # validated for 500+ live boards before import, so first launch is
+            # useful without starting a web-scale crawl.
+            for config in load_sources(snapshot, minimum_snapshot_sources=500):
+                registry.import_verified_snapshot(config)
+            for config in load_sources(sources):
+                registry.import_config(config.model_copy(update={"manual_override": True}))
+            session.commit()
+        has_verified = bool(registry.list_sources(enabled_only=True, verified_only=True, limit=1))
+    asyncio.run(_ingest(None if has_verified else str(sources), registry_mode=has_verified))
     mark_refreshed(data_dir)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "1.1.1"
+version = "1.1.2"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -11,8 +11,8 @@ _SPEC.loader.exec_module(validate_release_inputs)
 
 
 def test_release_version_sources_match():
-    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.1"
+    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.2"
 
 
 def test_release_validation_accepts_the_real_snapshot():
-    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.1"
+    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.2"


### PR DESCRIPTION
## Fix first-launch profile save during background refresh

Published v1.1.1 still reproduced SQLite lock failures when a fresh desktop launch refreshed sources while onboarding submitted the first profile. The refresh held the cross-process writer lock over network ingestion.

This patch keeps the lock only around the short bootstrap transaction; per-source ingestion already uses short database sessions. Version is bumped to v1.1.2. v1.0.0 and v1.1.0/v1.1.1 remain immutable.

Focused tests and Ruff pass locally; hosted CI and Windows packaging are required before release.