### PR TITLE
Release SQLite lock before provider fetch

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "europe-career-radar-web",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,5 +1,5 @@
 #ifndef AppVersion
-  #define AppVersion "1.1.2"
+  #define AppVersion "1.1.3"
 #endif
 #ifndef SourceDir
   #define SourceDir "build\\windows\\app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "1.1.2"
+version = "1.1.3"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/src/europe_visa_jobs/ingestion/pipeline.py
+++ b/src/europe_visa_jobs/ingestion/pipeline.py
@@ -23,8 +23,6 @@ async def ingest_source(
     sponsor_registry: SponsorRegistryStore | None = None,
 ) -> IngestionRun:
     run = IngestionRun(provider=source.provider.value, source_slug=source.slug)
-    session.add(run)
-    session.flush()
     repo = Repository(session)
     registry = SourceRegistry(session)
     registry_source = registry.get(source.provider.value, source.slug) or registry.import_config(source)
@@ -34,6 +32,11 @@ async def ingest_source(
         try:
             fetched = await connector.fetch_jobs()
         except ConnectorNotModified:
+            # Do not open a SQLite write transaction while waiting on the
+            # provider network request. The run row is added after fetch so
+            # profile/tracking writes can proceed during slow refreshes.
+            session.add(run)
+            session.flush()
             response_headers = getattr(connector, "last_response_headers", {})
             fetch_duration_ms = getattr(connector, "last_fetch_duration_ms", 0)
             registry.record_validation(
@@ -58,6 +61,12 @@ async def ingest_source(
             session.commit()
             return run
         run.fetched_count = len(fetched)
+
+        # The connector fetch above is intentionally outside the transaction.
+        # In particular, the desktop refresh must not hold SQLite's writer
+        # lock across a slow or rate-limited ATS response.
+        session.add(run)
+        session.flush()
 
         technical_jobs = [job for job in fetched if is_supported_tech_role(job.title)]
         sponsor_store = sponsor_registry or SponsorRegistryStore(repo.sponsor_evidence_for_jobs(technical_jobs))

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -11,8 +11,8 @@ _SPEC.loader.exec_module(validate_release_inputs)
 
 
 def test_release_version_sources_match():
-    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.2"
+    assert validate_release_inputs.validate(require_snapshot=False) == "1.1.3"
 
 
 def test_release_validation_accepts_the_real_snapshot():
-    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.2"
+    assert validate_release_inputs.validate(require_snapshot=True) == "1.1.3"


### PR DESCRIPTION
Fixes the remaining fresh-launch lock defect found in published v1.1.2. Ingestion no longer flushes an IngestionRun before awaiting the provider network response, so SQLite write transactions remain short while profile and tracking writes are accepted. Version bumped to v1.1.3. Earlier release tags remain immutable.