### PR TITLE
Fix durable SQLite ingestion batch timeout

### DIFF
--- a/src/europe_visa_jobs/ingestion/cli.py
+++ b/src/europe_visa_jobs/ingestion/cli.py
@@ -76,10 +76,13 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def _safe_ingestion_concurrency(settings) -> int:
-    # SQLite serializes writers; Postgres can use the configured bounded fan-out.
-    database_url = getattr(settings, "database_url", "")
+    # SQLite serializes writers, but each ingest task fetches its ATS payload
+    # before doing synchronous database work. Bounded fan-out therefore keeps
+    # slow public fetches from turning the durable branch-backed fallback into
+    # a serial 30-minute batch; the synchronous writes still run one at a time
+    # on the event loop.
     configured = getattr(settings, "ingestion_concurrency", 1)
-    return 1 if database_url.startswith("sqlite") else max(1, configured)
+    return max(1, configured)
 
 
 async def _ingest(

--- a/tests/test_source_live_components.py
+++ b/tests/test_source_live_components.py
@@ -32,6 +32,12 @@ def mock_client(payload, *, status=200, content_type="application/json"):
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
+def test_sqlite_ingestion_uses_bounded_fetch_fanout():
+    settings = type("Settings", (), {"database_url": "sqlite:///tmp.db", "ingestion_concurrency": 4})()
+
+    assert ingestion_cli._safe_ingestion_concurrency(settings) == 4
+
+
 @pytest.mark.asyncio
 async def test_additional_provider_connectors_normalize_public_shapes(monkeypatch):
     monkeypatch.setattr(


### PR DESCRIPTION
## Scope\n\nFix the proven daily-ingestion timeout on the branch-backed SQLite fallback. ATS payload fetches now use the configured bounded fan-out while synchronous SQLite writes remain event-loop serialized.\n\n## Verification\n\n- source/ingestion regression tests pass\n- Ruff and mypy pass\n- required follow-up: hosted CI, Windows package, and two consecutive daily-ingestion publications on the merged SHA