### PR TITLE
Allow full market-data refresh to complete

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   ingest:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # A full verified-registry refresh covers 771 ATS boards. Keep the full
+    # batch and allow enough wall-clock time for public provider rate limits.
+    timeout-minutes: 60
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       PYTHONPATH: src:.

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -45,3 +45,4 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "sqlite:///./source-health.sqlite" not in health
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
+    assert "timeout-minutes: 60" in daily


### PR DESCRIPTION
## Scope\n\nThe full 771-board verified-registry refresh is a required release gate. The proven 30-minute GitHub Actions timeout canceled both durable publication attempts before catalog publication. Keep full coverage and raise only the daily-ingest job timeout to 60 minutes.\n\n## Verification\n\n- release workflow regression assertion added\n- release/source/ingestion tests pass\n- Ruff passes\n- required follow-up: hosted checks, merge-SHA validation, and real publication cycles