### PR TITLE
Publish market data in resumable registry batches

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -15,8 +15,8 @@ concurrency:
 jobs:
   ingest:
     runs-on: ubuntu-latest
-    # A full verified-registry refresh covers 771 ATS boards. Keep the full
-    # batch and allow enough wall-clock time for public provider rate limits.
+    # Durable publication processes a bounded registry batch on each run and
+    # resumes the remaining verified boards from branch-backed state.
     timeout-minutes: 60
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -87,8 +87,8 @@ jobs:
           evj-ingest sources bootstrap --snapshot build/source-registry.latest.json --config config/sources.json
           evj-ingest sources discover --mode recent --method manual --limit 100
 
-      - name: Ingest current jobs from verified registry sources
-        run: evj-ingest jobs --registry --allow-partial --summary-file build/ingestion-summary.json
+      - name: Ingest a durable registry batch
+        run: evj-ingest jobs --registry --only-uningested --largest-first --limit 100 --allow-partial --summary-file build/ingestion-summary.json
 
       - name: Report persisted ingestion result
         run: |

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -45,4 +45,4 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "sqlite:///./source-health.sqlite" not in health
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
-    assert "timeout-minutes: 60" in daily
+    assert "--only-uningested --largest-first --limit 100" in daily


### PR DESCRIPTION
## Scope\n\nThe proven full 771-board daily refresh exceeded both 30-minute and 60-minute workflow limits before durable publication. Process 100 verified un-ingested boards per run, largest-first, and resume from branch-backed SQLite state on the next run. This preserves eventual full registry coverage while making each publication atomic and repeatable.\n\n## Verification\n\n- release workflow regression test passes\n- diff check passes\n- required follow-up: hosted CI, merge-SHA Windows gate, and two real consecutive publications