### PR TITLE
Fix market-data publication scope

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -161,7 +161,9 @@ jobs:
               expired.unlink()
           PY
           git checkout --orphan "market-data-catalog-${GITHUB_RUN_ID}"
-          git add -A
+          # Keep runner-local build databases and generated diagnostics out of the
+          # public data branch; only the catalog and durable state are published.
+          git add data/catalog data/state
           git commit -m "data: publish catalog ${GITHUB_RUN_ID}"
           git push --force origin HEAD:market-data
 

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -46,3 +46,5 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
     assert "--only-uningested --largest-first --limit 100" in daily
+    assert "git add data/catalog data/state" in daily
+    assert "git add -A" not in daily


### PR DESCRIPTION
Close the proven durable publication blocker from daily run 32781959403. The workflow previously used git add -A and attempted to push runner-local build/daily.sqlite (217.79 MB), which GitHub rejected. Publish only data/catalog and data/state, with a regression assertion.