### PR TITLE
Keep durable market-data publication clean

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -161,6 +161,9 @@ jobs:
               expired.unlink()
           PY
           git checkout --orphan "market-data-catalog-${GITHUB_RUN_ID}"
+          # The orphan checkout keeps the previous index; clear it without
+          # deleting the working-tree files before selecting the public payload.
+          git rm -r --cached . 2>/dev/null || true
           # Keep runner-local build databases and generated diagnostics out of the
           # public data branch; only the catalog and durable state are published.
           git add data/catalog data/state
@@ -175,6 +178,8 @@ jobs:
           from pathlib import Path
           summary = json.loads(Path("build/ingestion-summary.json").read_text())
           print(json.dumps(summary, indent=2))
+          if summary["sources_failed"] and not summary["partial_success"]:
+              raise SystemExit(f"{summary['sources_failed']} source(s) failed and no healthy source data was published")
           if summary["sources_failed"]:
-              raise SystemExit(f"{summary['sources_failed']} source(s) failed; healthy data and state were still published")
+              print(f"::warning::{summary['sources_failed']} source(s) failed; healthy data and state were still published")
           PY

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -46,5 +46,7 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
     assert "--only-uningested --largest-first --limit 100" in daily
+    assert "git rm -r --cached ." in daily
     assert "git add data/catalog data/state" in daily
     assert "git add -A" not in daily
+    assert "summary[\"sources_failed\"] and not summary[\"partial_success\"]" in daily


### PR DESCRIPTION
Fix the proven post-publication blockers from daily run 32785823278: clear the orphan branch index before staging so runner-local build and cache files cannot leak into market-data, and treat an explicitly partial-success batch as a warning while failing closed when no healthy sources publish. The already-published data is preserved; rerun both cycles after merge for clean branch evidence.