### PR TITLE
Make market-data branch index deterministic

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -161,9 +161,9 @@ jobs:
               expired.unlink()
           PY
           git checkout --orphan "market-data-catalog-${GITHUB_RUN_ID}"
-          # The orphan checkout keeps the previous index; clear it without
-          # deleting the working-tree files before selecting the public payload.
-          git rm -r --cached . 2>/dev/null || true
+          # The orphan checkout can retain the previous index; clear it without
+          # deleting working-tree files before selecting the public payload.
+          git read-tree --empty
           # Keep runner-local build databases and generated diagnostics out of the
           # public data branch; only the catalog and durable state are published.
           git add data/catalog data/state

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -46,7 +46,7 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
     assert "--only-uningested --largest-first --limit 100" in daily
-    assert "git rm -r --cached ." in daily
+    assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily
     assert "git add -A" not in daily
     assert "summary[\"sources_failed\"] and not summary[\"partial_success\"]" in daily


### PR DESCRIPTION
The first clean publication after PR #19 was green but independent branch inspection still showed legacy build/src/migrations files. The orphan index was not reliably empty. Use git read-tree --empty before staging data/catalog and data/state, with a regression assertion, then rerun the two release cycles.