### PR TITLE
release: allow truthful unsigned Windows artifacts

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -24,6 +24,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 60
+    outputs:
+      release_mode: ${{ steps.signing.outputs.mode }}
 
     steps:
       - name: Checkout
@@ -159,23 +161,37 @@ jobs:
         shell: pwsh
         env:
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_BASE64)) {
-            if ($env:GITHUB_REF -like "refs/tags/v*") {
-              throw "Tagged Windows releases require the WINDOWS_CERTIFICATE_BASE64 and WINDOWS_CERTIFICATE_PASSWORD secrets."
-            }
-            Write-Warning "No signing certificate is configured; this non-release artifact will be unsigned."
-            "enabled=false" >> $env:GITHUB_OUTPUT
+          $mode = & python scripts/windows_signing_mode.py
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows signing configuration is invalid."
+          }
+          $mode = $mode.Trim()
+          "mode=$mode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          if ($mode -eq "UNSIGNED") {
+            Write-Host "Windows release mode: UNSIGNED"
+            Write-Host "Authenticode was skipped because no signing certificate is configured."
+            @(
+              "### Windows release mode: UNSIGNED"
+              "Authenticode was skipped because no signing certificate is configured."
+              "SHA-256 checksums and package/runtime validation remain required."
+            ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+            "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
             exit 0
           }
 
+          Write-Host "Windows release mode: SIGNED"
+          "### Windows release mode: SIGNED" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
           $certificatePath = Join-Path $env:RUNNER_TEMP "career-radar-codesign.pfx"
-          [IO.File]::WriteAllBytes(
-            $certificatePath,
-            [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_BASE64)
-          )
+          try {
+            $certificateBytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_BASE64)
+            [IO.File]::WriteAllBytes($certificatePath, $certificateBytes)
+          } catch {
+            throw "Configured signing certificate is not valid Base64."
+          }
           "CAREERRADAR_SIGN_CERT=$certificatePath" >> $env:GITHUB_ENV
-          "enabled=true" >> $env:GITHUB_OUTPUT
+          "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Sign launcher binary
         if: steps.signing.outputs.enabled == 'true'
@@ -364,6 +380,7 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          WINDOWS_RELEASE_MODE: ${{ needs.build-windows.outputs.release_mode }}
         shell: bash
         run: |
           VERSION=$(node -p "require('./apps/web/package.json').version")
@@ -384,8 +401,26 @@ jobs:
 
           Advanced developers can use the repository's Docker/PostgreSQL/source installation documented in README.md.
 
-          Both Windows executables are Authenticode-signed and timestamped. Verify the included SHA-256 checksums before installation.
           EOF
+
+          if [[ "$WINDOWS_RELEASE_MODE" == "SIGNED" ]]; then
+            cat >> release-notes.md <<'EOF'
+
+          ### Windows package signing
+
+          The Windows launcher and installer are Authenticode-signed and timestamped. The published SHA-256 checksums can also be used to verify artifact integrity.
+          EOF
+          elif [[ "$WINDOWS_RELEASE_MODE" == "UNSIGNED" ]]; then
+            cat >> release-notes.md <<'EOF'
+
+          ### Windows package signing
+
+          This release's Windows package is unsigned because no Authenticode code-signing certificate is configured for this repository. The published SHA-256 checksums can be used to verify artifact integrity. Windows SmartScreen may display an unknown-publisher warning.
+          EOF
+          else
+            echo "Missing or invalid Windows release signing mode." >&2
+            exit 1
+          fi
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" release-assets/* --clobber

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -15,7 +15,12 @@ The signed release surface is:
 - `CareerRadar.exe`, the self-contained desktop launcher included in both installer and portable packages.
 - `CareerRadar-Setup-v<version>.exe`, the official Windows installer.
 
-Unsigned test artifacts may be produced for pull requests and non-release validation, but a tagged public Windows release must fail closed unless both executables receive a valid Authenticode signature.
+The workflow supports two truthful release modes. A `SIGNED` release uses Authenticode
+when both signing secrets are configured and verifies both executables. An `UNSIGNED`
+release is allowed when both signing secrets are absent; it preserves all package,
+smoke-test, manifest, and SHA-256 gates and clearly warns users that SmartScreen may
+show an unknown-publisher message. A partially configured secret pair or any signing
+failure fails the workflow; it never falls back to unsigned mode.
 
 ## Team roles
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Windows package bundles the Python backend runtime, the production Next.js s
 
 The v1.1 release package will create a local SQLite database, bootstrap a generated snapshot of live-verified ATS boards, load official sponsor-evidence records, fetch current ATS jobs, start the API and web app on loopback-only ports, and open the browser automatically. It will not run an internet-wide discovery crawl on desktop startup. A portable ZIP and SHA-256 checksums are published with the installer as well.
 
-See [`docs/WINDOWS.md`](docs/WINDOWS.md) for local-data paths, refresh behavior, portable usage, and Authenticode release requirements.
+Windows artifacts may be signed or unsigned depending on the configured release mode; release notes and [`docs/WINDOWS.md`](docs/WINDOWS.md) explain how to verify the package and its SHA-256 checksums.
 Third-party dataset provenance and reuse boundaries are documented in [`DATA_LICENSES.md`](DATA_LICENSES.md).
 
 ### Code signing policy

--- a/docs/PHASE_4.md
+++ b/docs/PHASE_4.md
@@ -190,7 +190,10 @@ Visa and sponsorship results are deterministic, evidence-based signals. They are
 
 The packaged seed catalog remains explicit and auditable, but it is no longer the production source universe. Coverage grows through the persistent registry and bounded discovery workflows; `config/sources.json` is retained for bootstrap, priority sources, and deterministic fixtures.
 
-Tagged Windows releases are fail-closed: publication requires the repository secrets
-`WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD`, and both executables
-must pass Authenticode verification. Unsigned pull-request artifacts are test-only and
-may still trigger SmartScreen.
+Windows release signing has two explicit modes. When both repository secrets
+`WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD` are configured, both
+release executables must pass strict Authenticode signing and verification. When both
+secrets are absent, a tagged release may be published as `UNSIGNED` after the same
+package, smoke, manifest, and SHA-256 gates pass; release notes document the mode and
+SmartScreen may show an unknown-publisher warning. A partially configured pair fails
+closed. The current release workflow never masks a signing failure as unsigned.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -80,7 +80,8 @@ This checklist is intentionally evidence-driven. Items are checked only after th
 - [ ] Installed runtime terminates backend and Node child processes cleanly
 - [ ] Portable ZIP extracts cleanly and passes the same no-host-runtime smoke test
 - [ ] User data remains under `%LOCALAPPDATA%\\CareerRadar` across upgrades
-- [ ] `WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD` are configured; both Windows executables have valid Authenticode signatures
+- [ ] Windows signing mode is recorded in workflow output and release notes; if `SIGNED`, both executables have valid Authenticode signatures, and if `UNSIGNED`, both signing secrets are absent
+- [ ] A partially configured signing-secret pair fails closed; signing failures are never masked as unsigned
 - [ ] The release tag targets the final validated main commit
 - [ ] GitHub Release attaches the exact verified Setup, Portable, and checksum files
 - [ ] Release assets are downloaded from GitHub and hashes are re-verified

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -76,7 +76,13 @@ it has the same dependency-free runtime as the installer.
 ## Integrity
 
 `SHA256SUMS.txt` in the release contains SHA-256 hashes for the installer and portable ZIP.
+Verify both downloaded files against this checksum file before installation.
 
 ## Windows code signing
 
-Tagged release artifacts are Authenticode-signed and timestamped. The release workflow refuses to publish a tag unless the repository secrets `WINDOWS_CERTIFICATE_BASE64` (a base64-encoded PFX) and `WINDOWS_CERTIFICATE_PASSWORD` are configured. Pull-request artifacts may remain unsigned and are test-only.
+The workflow supports two explicit release modes:
+
+- **SIGNED**: when both `WINDOWS_CERTIFICATE_BASE64` (a base64-encoded PFX) and `WINDOWS_CERTIFICATE_PASSWORD` are configured, the launcher and installer are Authenticode-signed and the signatures are verified. A malformed certificate, wrong password, signing failure, or invalid signature fails the workflow.
+- **UNSIGNED**: when both signing secrets are absent, signing is skipped and the release remains eligible after all package, smoke, manifest, and checksum gates pass. Windows SmartScreen may show an unknown-publisher warning; use `SHA256SUMS.txt` to verify artifact integrity.
+
+If exactly one signing secret is configured, the workflow fails as a configuration error. The release notes always state the actual mode.

--- a/scripts/windows_signing_mode.py
+++ b/scripts/windows_signing_mode.py
@@ -1,0 +1,41 @@
+"""Resolve the Windows release signing mode without exposing credentials."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def resolve_signing_mode(
+    certificate_base64: str | None,
+    certificate_password: str | None,
+) -> str:
+    """Return SIGNED/UNSIGNED, rejecting a partially configured signing setup."""
+
+    has_certificate = bool(certificate_base64 and certificate_base64.strip())
+    has_password = bool(certificate_password and certificate_password.strip())
+    if has_certificate != has_password:
+        raise ValueError(
+            "Windows signing is partially configured. Both "
+            "WINDOWS_CERTIFICATE_BASE64 and WINDOWS_CERTIFICATE_PASSWORD must be present, "
+            "or both must be absent."
+        )
+    return "SIGNED" if has_certificate else "UNSIGNED"
+
+
+def main() -> int:
+    try:
+        mode = resolve_signing_mode(
+            os.environ.get("WINDOWS_CERTIFICATE_BASE64"),
+            os.environ.get("WINDOWS_CERTIFICATE_PASSWORD"),
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(mode)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -9,6 +9,12 @@ assert _SPEC and _SPEC.loader
 validate_release_inputs = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(validate_release_inputs)
 
+_SIGNING_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "windows_signing_mode.py"
+_SIGNING_SPEC = importlib.util.spec_from_file_location("windows_signing_mode", _SIGNING_SCRIPT)
+assert _SIGNING_SPEC and _SIGNING_SPEC.loader
+windows_signing_mode = importlib.util.module_from_spec(_SIGNING_SPEC)
+_SIGNING_SPEC.loader.exec_module(windows_signing_mode)
+
 
 def test_release_version_sources_match():
     assert validate_release_inputs.validate(require_snapshot=False) == "1.1.4"
@@ -29,6 +35,36 @@ def test_release_validation_can_require_sponsor_provenance_hashes(monkeypatch):
     monkeypatch.setattr(validate_release_inputs, "validate_registry", fake_validate_registry)
     assert validate_release_inputs.validate(require_snapshot=False, require_input_hashes=True) == "1.1.4"
     assert called["kwargs"]["require_input_hashes"] is True
+
+
+def test_windows_signing_mode_truth_table():
+    assert windows_signing_mode.resolve_signing_mode(None, None) == "UNSIGNED"
+    assert windows_signing_mode.resolve_signing_mode("base64-pfx", "pfx-password") == "SIGNED"
+
+    for certificate, password in (("base64-pfx", None), (None, "pfx-password")):
+        try:
+            windows_signing_mode.resolve_signing_mode(certificate, password)
+        except ValueError as exc:
+            assert str(exc) == (
+                "Windows signing is partially configured. Both "
+                "WINDOWS_CERTIFICATE_BASE64 and WINDOWS_CERTIFICATE_PASSWORD must be present, "
+                "or both must be absent."
+            )
+        else:
+            raise AssertionError("partial Windows signing configuration must fail")
+
+
+def test_windows_workflow_surfaces_signing_mode_and_keeps_strict_signing():
+    root = Path(__file__).resolve().parents[1]
+    windows = (root / ".github" / "workflows" / "windows-package.yml").read_text(encoding="utf-8")
+    assert "scripts/windows_signing_mode.py" in windows
+    assert "release_mode: ${{ steps.signing.outputs.mode }}" in windows
+    assert "Windows release mode: UNSIGNED" in windows
+    assert "Windows release mode: SIGNED" in windows
+    assert "Authenticode was skipped because no signing certificate is configured." in windows
+    assert "if ($LASTEXITCODE -ne 0) { throw \"Launcher signing failed" in windows
+    assert "if ($LASTEXITCODE -ne 0) { throw \"Installer signing failed" in windows
+    assert "WINDOWS_RELEASE_MODE: ${{ needs.build-windows.outputs.release_mode }}" in windows
 
 
 def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():


### PR DESCRIPTION
## Summary\n- make Windows Authenticode signing explicit and optional\n- fail closed on partially configured or invalid signing credentials\n- surface SIGNED/UNSIGNED mode in workflow summaries and release notes\n- preserve package, smoke, checksum, and ingestion gates\n- add regression coverage and update release documentation\n\nCurrent v1.1.4 release mode is intended to be UNSIGNED because both signing secrets are absent.