### PR TITLE
docs: adopt noncommercial licensing and refresh README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,11 @@ CODE_SIGNING_POLICY.md @MahdiNavaei
 PRIVACY.md @MahdiNavaei
 .signpath/ @MahdiNavaei
 packaging/windows/ @MahdiNavaei
+
+# Licensing-sensitive paths
+LICENSE @MahdiNavaei
+NOTICE @MahdiNavaei
+COMMERCIAL_LICENSE.md @MahdiNavaei
+DATA_LICENSES.md @MahdiNavaei
+CONTRIBUTING.md @MahdiNavaei
+pyproject.toml @MahdiNavaei

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -1,0 +1,42 @@
+# Commercial licensing
+
+Career Radar / Europe Visa Sponsorship Jobs is publicly source-available under the
+[PolyForm Noncommercial License 1.0.0](LICENSE).
+
+The public license does **not** grant commercial-use rights.
+
+A separate written commercial license is required if you want to use this software
+for a commercial purpose, including, for example:
+
+- internal use by a for-profit business where the use supports commercial operations,
+- integration into a paid product or service,
+- offering Career Radar or a derivative as a hosted or managed service,
+- redistribution, OEM bundling, or resale in a commercial offering,
+- using substantial portions of the software in commercial consulting or client delivery.
+
+Commercial terms can be tailored for startups, established companies, hosted services,
+OEM use, partnerships, and other deployment models.
+
+## Contact
+
+For commercial licensing, partnerships, or project sponsorship, contact **Mahdi Navaei**
+through the contact information published on the repository owner's GitHub profile:
+
+https://github.com/MahdiNavaei
+
+Please include a short description of the intended use, organization, deployment model,
+and whether you need redistribution or hosted-service rights.
+
+## Sponsorship is separate from licensing
+
+Financial sponsorship or support for the project does not automatically grant
+commercial-use rights unless a separate written agreement explicitly says so.
+
+## Earlier MIT-licensed versions
+
+Versions that were previously released under the MIT License retain the permissions
+that accompanied those versions. The current commercial licensing model applies to
+versions distributed under the PolyForm Noncommercial License 1.0.0.
+
+This document is an invitation to discuss commercial terms; it is not itself a grant
+of commercial rights.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing
 
-Thanks for helping improve Europe Visa Sponsorship Jobs.
+Thanks for helping improve Europe Visa Sponsorship Jobs / Career Radar.
 
-The project is designed to become community-driven once public. Accuracy matters more than job volume: a false claim that a vacancy supports immigration can waste a candidate's time.
+Accuracy matters more than job volume: a false claim that a vacancy supports
+immigration can waste a candidate's time.
 
-## Phase 1 contribution areas
+## Useful contribution areas
 
 Contributions are especially useful for:
 
@@ -15,17 +16,37 @@ Contributions are especially useful for:
 - hard restriction phrases
 - country and city normalization
 - technical role classification
-- tests and documentation
+- tests, accessibility, and documentation
 
 ## Non-negotiable rules
 
-1. **No paid LLM/API dependency.** Phase 1 must run without OpenAI, Anthropic, Gemini, or similar services.
-2. **Evidence over guesses.** Missing evidence should produce `unknown`, not `eligible`.
+1. **No paid LLM/API dependency at runtime.** The core product must remain usable without OpenAI, Anthropic, Gemini, or similar paid services.
+2. **Evidence over guesses.** Missing evidence should not be promoted into a positive sponsorship claim.
 3. **Hard negatives win.** Existing-work-authorization, citizenship, EU/EEA-only, or no-sponsorship restrictions must override positive wording.
 4. **A sponsor company does not imply every job is sponsored.** Vacancy-level evidence is still required.
 5. **Prefer first-party sources.** Use documented/public company ATS feeds and official immigration/sponsor sources where possible.
 6. **Do not bypass authentication, anti-bot controls, or website restrictions.**
 7. **Add tests with behavior changes.**
+
+## Contribution licensing
+
+The public repository is licensed under the PolyForm Noncommercial License 1.0.0.
+By submitting a contribution, you represent that you have the right to submit it and
+agree that the contribution may be distributed as part of this project under the
+repository's public license.
+
+To preserve the project's dual-licensing model, you also grant **Mahdi Navaei**, as
+project maintainer, a perpetual, worldwide, non-exclusive, royalty-free license to use,
+reproduce, modify, distribute, sublicense, and relicense your contribution, including
+under commercial terms. This additional grant applies only to the contribution you
+submit and does not transfer ownership of your copyright.
+
+If you do not have the authority to make these grants, do not submit the contribution.
+If your employer or another party owns rights in your work, obtain any required
+permission first.
+
+See [`LICENSE`](LICENSE), [`NOTICE`](NOTICE), and
+[`COMMERCIAL_LICENSE.md`](COMMERCIAL_LICENSE.md).
 
 ## Development setup
 
@@ -71,7 +92,8 @@ Country route metadata belongs in `eligibility/country_rules.py`.
 
 Textual sponsorship/restriction evidence belongs in `eligibility/signals.py`.
 
-Do not hard-code volatile salary thresholds into regex rules. Time-sensitive legal thresholds should be maintained as dated datasets with an official source.
+Do not hard-code volatile salary thresholds into regex rules. Time-sensitive legal
+thresholds should be maintained as dated datasets with an official source.
 
 ## Pull requests
 
@@ -82,5 +104,6 @@ Before opening a PR:
 - run the migration smoke test for schema changes
 - document new public data sources
 - explain false-positive/false-negative implications for eligibility changes
+- confirm that you can make the contribution-licensing grants described above
 
-The project deliberately prefers false negatives over false positives for the default user-facing job list.
+The project deliberately prioritizes evidence quality over inflated coverage claims.

--- a/DATA_LICENSES.md
+++ b/DATA_LICENSES.md
@@ -1,7 +1,9 @@
 # Data sources, terms, and attribution
 
-Career Radar's software is MIT-licensed. That license does not relicense third-party
-job postings, company pages, or government registers included in generated datasets.
+Career Radar's software is source-available under the repository's
+PolyForm Noncommercial License 1.0.0. That software license does not relicense
+third-party job postings, company pages, government registers, or other upstream
+content included in generated datasets.
 
 ## Job-board data
 
@@ -20,12 +22,22 @@ particular role or candidate will be sponsored.
 
 ## Generated catalog snapshots
 
-Catalog manifests and normalized factual fields produced by this project may be used
-under the repository's MIT license only to the extent the project owns those fields.
-Embedded third-party text and metadata retain their original rights and terms.
+Project-owned code, schemas, transformations, and original authored material are
+covered by the repository software license unless a file says otherwise. Generated
+catalog manifests and normalized factual fields may also contain or refer to third-party
+material whose original rights and terms remain in force.
+
 Redistributors should preserve provenance, generation timestamps, eligibility evidence,
-and this notice, and should not present stale snapshots as current vacancies.
+the repository's required notices, and this data notice. They must not present stale
+snapshots as current vacancies.
 
 No API keys, access tokens, candidate profiles, notes, or application tracking records
 belong in published market-data snapshots. Publication validation must fail if secret
 material is detected.
+
+## Commercial use
+
+The repository's public PolyForm license does not grant commercial-use rights in the
+project-owned software. See `COMMERCIAL_LICENSE.md` for commercial licensing.
+Third-party data rights remain separate and may require additional permission from the
+relevant source regardless of any commercial license granted for Career Radar itself.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,25 @@
-MIT License
+PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2026 Mahdi Navaei
+SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+Canonical license terms: https://polyformproject.org/licenses/noncommercial/1.0.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Required Notice: Copyright 2026 Mahdi Navaei.
+Required Notice: Career Radar / Europe Visa Sponsorship Jobs is an original project by Mahdi Navaei. Original repository: https://github.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The software in this repository is made available under the PolyForm Noncommercial
+License 1.0.0. The canonical terms at the URL above govern this license.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Noncommercial use, modification, and redistribution are permitted subject to those
+terms and the required notices above. Commercial use is not granted by this public
+license. See COMMERCIAL_LICENSE.md for commercial licensing information.
+
+Third-party job postings, employer content, government registers, dependencies, and
+other third-party materials are not relicensed by this file. See DATA_LICENSES.md and
+the relevant upstream terms for those materials.
+
+License history
+---------------
+Versions of this project that were previously published with the MIT License retain
+the MIT permissions that accompanied those versions. This PolyForm license applies
+to versions distributed with this LICENSE file; it does not retroactively revoke
+permissions already granted for earlier MIT-licensed versions.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Required Notice: Copyright 2026 Mahdi Navaei.
+Required Notice: Career Radar / Europe Visa Sponsorship Jobs is an original project by Mahdi Navaei. Original repository: https://github.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs

--- a/README.md
+++ b/README.md
@@ -1,93 +1,126 @@
-# Europe Visa Sponsorship Jobs — Career Radar
+# Career Radar — Europe Visa Sponsorship Jobs
 
 > Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship or relocation support.
 
-**Career Radar v1.1.4** is a strict, explainable career radar: it collects current technical vacancies, rejects hard work-authorization restrictions, evaluates sponsorship evidence, ranks opportunities against a candidate profile, and explains why a job is—or is not—a realistic target.
+[![CI](https://github.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs/actions/workflows/ci.yml/badge.svg)](https://github.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs/actions/workflows/ci.yml)
+[![License: PolyForm Noncommercial 1.0.0](https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml)
+[![Windows](https://img.shields.io/badge/Windows-installer-0078D6.svg)](docs/WINDOWS.md)
 
-It uses **no LLM and no paid AI API at runtime**. Decisions are deterministic, inspectable, reproducible, and backed by stored evidence.
+**Career Radar v1.1.4** helps international candidates stop wasting applications on jobs that cannot realistically sponsor them.
+
+It collects current technical vacancies from public employer ATS feeds, identifies hard work-authorization restrictions, evaluates sponsorship and relocation evidence, ranks jobs against a candidate profile, and explains the evidence behind every decision.
+
+No LLM and no paid AI API are required at runtime. The core decision path is deterministic, inspectable, reproducible, and evidence-backed.
 
 ![Career Radar dashboard](docs/assets/dashboard-en.png)
 
-## Windows — one-click install
+## Why Career Radar exists
 
-For most Windows users, no developer setup is needed.
-
-1. Open **GitHub Releases**.
-2. Download the setup file matching the current release version (for example, `CareerRadar-Setup-v1.1.4.exe`).
-3. Install and launch **Career Radar**.
-
-The Windows package bundles the Python backend runtime, the production Next.js server, a private Node runtime, database migrations, and project configuration. Users do **not** need to install Python, Node.js, npm packages, pip packages, Docker, or PostgreSQL.
-
-The v1.1 release package will create a local SQLite database, bootstrap a generated snapshot of live-verified ATS boards, load official sponsor-evidence records, fetch current ATS jobs, start the API and web app on loopback-only ports, and open the browser automatically. It will not run an internet-wide discovery crawl on desktop startup. A portable ZIP and SHA-256 checksums are published with the installer as well.
-
-Windows artifacts may be signed or unsigned depending on the configured release mode; release notes and [`docs/WINDOWS.md`](docs/WINDOWS.md) explain how to verify the package and its SHA-256 checksums.
-Third-party dataset provenance and reuse boundaries are documented in [`DATA_LICENSES.md`](DATA_LICENSES.md).
-
-### Code signing policy
-
-Free code signing provided by SignPath.io, certificate by SignPath Foundation. Official Windows release artifacts follow the repository's [`Code signing policy`](CODE_SIGNING_POLICY.md). Desktop data handling is documented in [`PRIVACY.md`](PRIVACY.md).
-
-## Why this project exists
-
-International candidates routinely lose time on vacancies that look global but later contain restrictions such as:
+A job can look international and still contain a single sentence that makes it unusable for a non-EU candidate:
 
 - `must already have the right to work`
 - `no visa sponsorship`
 - `EU/EEA candidates only`
 - `must currently reside in the EU`
 
-Career Radar treats those sentences as first-class eligibility data rather than footnotes.
+Traditional job search treats those lines as ordinary description text. Career Radar treats them as first-class eligibility evidence.
 
-A company appearing in a sponsor register is **not** enough to approve every vacancy. Job-level evidence still matters, and hard negative restrictions always win.
+It also avoids a common false positive: **a company appearing on a sponsor register does not mean every vacancy at that company is sponsored.** Job-level evidence still matters, and explicit restrictions take priority over positive company-level signals.
 
-## What v1.1 includes
+## What it does
 
-- Public ATS connectors: Greenhouse, Lever, Ashby, Workable, Personio
-- Generated, validated source-registry snapshot for desktop bootstrap (the release build rejects a snapshot with fewer than 500 verified boards)
-- Daily source refresh workflow
-- Technical-role classification
-- Country inference and normalized job identity
-- Visa, relocation, international-candidate, and hard-restriction detection
-- Country-specific immigration rule registry
-- Compressed official UKVI and IND sponsor-registry evidence cache, loaded before production eligibility analysis
-- Strict `eligible / rejected / unknown` eligibility states
+### Find realistic opportunities
+
+- Connects to public Greenhouse, Lever, Ashby, Workable, and Personio job feeds
+- Normalizes companies, countries, locations, roles, and stable job identities
+- Detects sponsorship, relocation, international-candidate, and hard-restriction evidence
+- Uses country-specific immigration rules and official sponsor-register evidence
+- Tracks evidence instead of returning unexplained yes/no predictions
+
+### Match jobs to a candidate
+
 - Candidate profiles and deterministic skill ontology
-- Explainable candidate/job matching and ranking
+- Visa compatibility and sponsorship evidence
+- Skill coverage and role similarity
+- Experience and seniority fit
+- Country preferences
+- Explainable ranking and recommendation scores
+
+### Track the search
+
+- Saved jobs
+- Application stages
 - Company visa-friendliness intelligence
-- Saved jobs and application-stage tracking
-- FastAPI + PostgreSQL backend
-- Bilingual Next.js application (`/en`, `/fa`) with true RTL Persian
-- Light/dark themes and responsive desktop/mobile UI
-- Docker production stack
-- Dependency-free Windows installer + portable package
-- PostgreSQL migration round-trip validation
-- Chromium, Firefox, and WebKit E2E coverage
-- Accessibility, security, dependency, and public-repository audits
-- Lighthouse performance budgets
-- Live public-ATS-to-browser E2E validation
+- Bilingual English/Persian interface
+- True RTL Persian layout
+- Light/dark themes
+- Responsive desktop/mobile UI
 
-## Strict eligibility policy
+## Eligibility model
 
-| Status | Meaning | Default UI/API |
-|---|---|---:|
-| `eligible` | Strong sponsorship/relocation evidence and no hard restriction | Shown |
-| `rejected` | A hard restriction was found | Hidden |
-| `unknown` | Evidence is incomplete or ambiguous | Hidden |
+Career Radar uses three explicit evidence states:
 
-The system intentionally prefers false negatives over false positives. If it cannot prove enough, the job stays `unknown` instead of wasting a candidate's time.
+| Status | Meaning |
+|---|---|
+| `eligible` | Sufficient positive sponsorship/relocation evidence and no overriding hard restriction |
+| `rejected` | A hard work-authorization or sponsorship restriction was found |
+| `unknown` | Available evidence is incomplete or ambiguous |
 
-## Verified live-data path
+The system intentionally avoids turning uncertainty into a sponsorship claim. Evidence and reason codes are retained so decisions can be inspected and refreshed as employer policies change.
 
-Phase 4 contains a networked E2E gate with **no mocked job data path**:
+## Windows — one-click install
+
+For most Windows users, no developer setup is needed.
+
+1. Open **GitHub Releases**.
+2. Download the setup file matching the current release, for example `CareerRadar-Setup-v1.1.4.exe`.
+3. Install and launch **Career Radar**.
+
+The Windows package includes the Python backend runtime, production Next.js server, private Node runtime, database migrations, and project configuration. Users do **not** need to install Python, Node.js, npm packages, pip packages, Docker, or PostgreSQL.
+
+On first launch, Career Radar creates a local SQLite database, loads the packaged verified source-registry snapshot and sponsor evidence, synchronizes the current market catalog, starts the API and web application on loopback-only ports, and opens the browser automatically.
+
+A portable ZIP and SHA-256 checksums are published with release assets.
+
+Windows artifacts may be signed or unsigned depending on the configured release mode. The release notes state the actual mode for each release, and SHA-256 integrity artifacts remain mandatory regardless of signing mode. Unsigned builds may trigger a Windows SmartScreen unknown-publisher warning. See [`docs/WINDOWS.md`](docs/WINDOWS.md) and [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
+
+Desktop privacy behavior is documented in [`PRIVACY.md`](PRIVACY.md).
+
+## Live data and daily refresh
+
+Career Radar maintains a verified source registry rather than assuming every discovered ATS slug is valid forever.
+
+The scheduled `.github/workflows/daily-ingest.yml` workflow runs daily and can also be triggered manually. It:
+
+1. migrates the persistent database,
+2. bootstraps the verified source registry and audited manual seeds,
+3. fetches current ATS vacancies,
+4. upserts jobs deterministically,
+5. deactivates disappeared jobs only when provider enumeration is complete,
+6. re-runs eligibility analysis,
+7. publishes updated catalog state and refresh statistics.
+
+When a hosted deployment provides `DATABASE_URL`, it can use persistent PostgreSQL. Without that secret, the workflow uses the project's sanitized branch-backed durable data path.
+
+Daily refresh means configured sources are checked every day. It does **not** imply that employers publish a new eligible vacancy every calendar day.
+
+### Verified release path
+
+Release validation has exercised the complete production path with real public ATS data rather than mocked job records:
 
 ```text
 Public ATS
    ↓
 Connector + normalization
    ↓
+Sponsorship / restriction evidence
+   ↓
+Country rules + sponsor evidence
+   ↓
 Eligibility engine
    ↓
-PostgreSQL
+PostgreSQL / local SQLite
    ↓
 FastAPI
    ↓
@@ -96,59 +129,15 @@ Production Next.js
 Real browser → Job detail → Apply URL
 ```
 
-Release validation on **2026-08-21 UTC** verified all 10 configured production feeds live and fetched **1,373 raw current positions** across them.
+The v1.1 release validation on 2026-08-21 UTC checked all 10 configured production feeds live and fetched **1,373 raw current positions**. An independent Greenhouse + Ashby smoke set was ingested twice into fresh PostgreSQL and verified through the API and production browser path, including real outbound application links.
 
-A smaller independent Greenhouse + Ashby smoke set was then ingested twice into fresh PostgreSQL:
+Live upstream services change, so current source health is continuously revalidated rather than inferred from historical success.
 
-- 96 active technical jobs
-- 79 postings inside the 60-day freshness window
-- 40 strict-mode eligible jobs
-- identical source/external-id key set after immediate re-ingestion
-- real FastAPI response verified
-- real production Next.js UI verified in Chromium
-- job detail and outbound application link verified
+## Source coverage
 
-The smoke run included current postings from N26 and Clera dated August 19–21, 2026.
+`config/sources.json` is a small auditable bootstrap seed set. Production registry operations use the persisted verified registry and generated source snapshot.
 
-Live upstream services can change, so CI also validates the configured source catalog rather than assuming ATS slugs remain valid forever.
-
-## Daily refresh: what it guarantees
-
-`.github/workflows/daily-ingest.yml` is scheduled for **03:17 UTC every day** and can also be dispatched manually.
-
-It:
-
-1. migrates the persistent database,
-2. bootstraps the generated verified source registry and audited manual seeds,
-3. re-fetches current ATS vacancies,
-4. upserts jobs deterministically,
-5. deactivates jobs that disappeared only when provider enumeration is complete,
-6. re-runs eligibility analysis,
-7. reports active, eligible, and newest-posting statistics.
-
-A hosted deployment should provide persistent PostgreSQL through `DATABASE_URL`.
-When the secret is absent, the workflow restores and republishes a sanitized,
-branch-backed SQLite checkpoint instead of losing state between runners.
-
-**Daily refresh does not mean employers publish a new eligible vacancy every calendar day.** It means the configured feeds are checked every day, and newly published eligible jobs appear after the next successful refresh.
-
-The Windows desktop runtime opens the local UI after migration/seed and synchronizes the
-global catalog in the background. A manual refresh remains available, but it is not
-required for routine updates. Cached catalog data remains usable offline.
-
-Career Radar refreshes configured sources daily and surfaces newly discovered eligible opportunities. This does not guarantee that an employer publishes a new eligible vacancy every calendar day.
-
-## Source coverage and refresh
-
-`config/sources.json` is the small, auditable manual seed set. It is only a bootstrap
-input. Scheduled discovery and source health use `SOURCE_STATE_DATABASE_URL` when
-configured and otherwise use the sanitized branch-backed SQLite checkpoint. Daily
-ingestion publishes a versioned gzip catalog plus `latest.json` to the `market-data`
-branch. Existing clients consume that manifest without reinstalling.
-The packaged `config/source-registry.snapshot.json` remains an offline fallback, not the
-continuously updated source universe.
-
-The manual seeds currently include public feeds for:
+The bootstrap seeds currently include public feeds for:
 
 - N26
 - HelloFresh
@@ -161,51 +150,45 @@ The manual seeds currently include public feeds for:
 - PRISMA European Capacity Platform
 - Clera
 
-Provider pages and archived/index URLs are candidates, never coverage claims. A
-board enters the snapshot only after its current provider endpoint (or a
-documented provider fallback) succeeds. Coverage metrics always describe the
-monitored catalog, not all European vacancies.
+A provider page, archive, or search result is only a discovery candidate. It becomes part of the verified catalog after its current provider endpoint or documented fallback passes validation.
+
+Daily ingestion publishes a versioned compressed market catalog plus `latest.json` to the `market-data` branch. Existing clients can consume updated market data without reinstalling the desktop application. The packaged `config/source-registry.snapshot.json` is an offline fallback, not the continuously updated source universe.
 
 ## Architecture
 
 ```text
 ATS connectors
-   │
    ├─ Greenhouse
    ├─ Lever
    ├─ Ashby
    ├─ Workable
    └─ Personio
-   ↓
+          ↓
 Normalization + role classification
-   ↓
+          ↓
 Visa / relocation / restriction evidence
-   ↓
-Country rules + sponsor evidence
-   ↓
+          ↓
+Country rules + official sponsor evidence
+          ↓
 Strict eligibility engine
-   ↓
+          ↓
 PostgreSQL / local Windows SQLite
    ├─ jobs + evidence
    ├─ companies + sponsor records
    ├─ candidates
    ├─ application states
    └─ ingestion runs
-
-Global market data is published separately from local candidate state. Catalog imports
-are hash-verified, staged, and transactional; profiles, saved jobs, application
-tracking, notes, and preferences are never replaced by a market-data update. See
-[`docs/data-delivery.md`](docs/data-delivery.md) for the manifest and provider
-completeness contract.
-   ↓
+          ↓
 Candidate matching + ranking
-   ↓
+          ↓
 FastAPI
-   ↓
-Next.js Career Radar (EN / FA RTL)
+          ↓
+Next.js Career Radar — EN / FA RTL
 ```
 
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`docs/PHASE_2.md`](docs/PHASE_2.md), [`docs/PHASE_3.md`](docs/PHASE_3.md), and [`docs/PHASE_4.md`](docs/PHASE_4.md).
+Global market data is separated from local candidate state. Catalog imports are hash-verified, staged, and transactional; profiles, saved jobs, application tracking, notes, and preferences are not replaced by market-data updates.
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/data-delivery.md`](docs/data-delivery.md).
 
 ## Developer quick start
 
@@ -239,8 +222,6 @@ The web app defaults to `http://localhost:8000` for the API. Set `NEXT_PUBLIC_AP
 
 ### Production-like Docker stack
 
-A production-style stack with PostgreSQL, FastAPI, and standalone Next.js is provided:
-
 ```bash
 export POSTGRES_PASSWORD='choose-a-strong-password'
 docker compose -f docker-compose.production.yml up -d --build
@@ -250,17 +231,10 @@ The production compose file intentionally has no default database password.
 
 ## Run real job ingestion
 
-The manual seeds are in `config/sources.json`; production registry operations
-use the persisted verified registry.
-
 ```bash
 evj-ingest sources bootstrap --config config/sources.json --snapshot config/source-registry.snapshot.json
 evj-ingest jobs --registry
 ```
-
-To maintain a custom deployment, edit that catalog or start from `config/sources.example.json` and validate the ATS slugs before relying on them.
-
-## Demo data
 
 For UI development without external network traffic:
 
@@ -270,7 +244,9 @@ python scripts/seed_demo.py
 
 The demo dataset is deterministic and fictional; it never claims that a real employer sponsors a fictional vacancy.
 
-## Candidate intelligence API
+## API examples
+
+### Candidate intelligence
 
 ```http
 POST /api/v1/candidates
@@ -279,11 +255,9 @@ GET  /api/v1/recommendations/{candidate_id}
 GET  /api/v1/recommendations/{candidate_id}/explain
 ```
 
-Recommendations combine visa compatibility, skill coverage, experience/seniority, country preference, role similarity, and company evidence. Ranking weights live in [`config/ranking.yaml`](config/ranking.yaml), while skill aliases/categories live in [`data/skills.yaml`](data/skills.yaml).
+Ranking weights live in [`config/ranking.yaml`](config/ranking.yaml), while skill aliases and categories live in [`data/skills.yaml`](data/skills.yaml).
 
-## Job API
-
-Default behavior returns eligible jobs only:
+### Jobs
 
 ```http
 GET /api/v1/jobs
@@ -291,7 +265,7 @@ GET /api/v1/jobs/{id}
 GET /api/v1/jobs?country=Germany&category=ai_ml&limit=20&offset=0
 ```
 
-Pagination exposes `X-Total-Count`. Job detail returns the evidence used by the eligibility engine.
+Job detail responses expose the evidence used by the eligibility engine.
 
 ## Verification
 
@@ -314,39 +288,72 @@ npm run build
 npx playwright test
 ```
 
-Release CI additionally validates:
+Release CI additionally covers:
 
 - Python 3.11 and 3.12
 - SQLite and PostgreSQL Alembic round trips
 - backend and frontend production builds
-- Chromium / Firefox / WebKit critical flows
+- Chromium, Firefox, and WebKit critical flows
 - live public ATS source health
-- live ATS → PostgreSQL → API → production browser E2E
-- Windows self-contained installer build and silent-install smoke test
+- live ATS → PostgreSQL → API → production-browser E2E
+- Windows self-contained package and silent-install smoke tests
 - `pip-audit` and `npm audit --audit-level=high`
-- secret/local-artifact/public-repository safety
+- secret/local-artifact/public-repository safety checks
 - accessibility and responsive behavior
 - Lighthouse budgets for English and Persian
 - fresh-checkout production Docker acceptance
 
 ## Project status
 
-All four v1 phases are implemented:
+All four original v1 implementation phases are complete:
 
 1. **Core Platform & Data Intelligence Engine** ✅
 2. **Candidate Matching & Intelligence** ✅
 3. **Professional bilingual UI/UX** ✅
 4. **Full Testing, Integration & E2E Hardening** ✅
 
-See [`docs/ROADMAP.md`](docs/ROADMAP.md).
+See [`docs/ROADMAP.md`](docs/ROADMAP.md) and [`CHANGELOG.md`](CHANGELOG.md).
 
-## Accuracy and legal boundary
+## Accuracy, data, and legal boundary
 
-Visa and sponsorship results are deterministic evidence signals, **not legal or immigration advice and not a sponsorship guarantee**. Employer policy and immigration rules can change after data is collected. Evidence is retained so decisions can be audited and refreshed.
+Visa and sponsorship results are deterministic evidence signals, **not legal or immigration advice and not a sponsorship guarantee**. Employer policies, vacancies, and immigration rules can change after data is collected.
 
-## License
+Third-party job descriptions, company content, and government-register data retain their original rights and terms. See [`DATA_LICENSES.md`](DATA_LICENSES.md).
 
-MIT
+## License and commercial use
+
+Career Radar is **source-available** under the **PolyForm Noncommercial License 1.0.0** (`PolyForm-Noncommercial-1.0.0`). It is not presented as an OSI-approved open-source license.
+
+In practical terms:
+
+- personal, educational, research, hobby, and other noncommercial use is permitted under the license terms,
+- modification and noncommercial redistribution are permitted under those terms,
+- the required copyright/project notices must be preserved,
+- **commercial use requires a separate written license** from the project owner.
+
+See [`LICENSE`](LICENSE), [`NOTICE`](NOTICE), and [`COMMERCIAL_LICENSE.md`](COMMERCIAL_LICENSE.md).
+
+Versions previously released under MIT retain the MIT permissions that accompanied those versions; the license change is not retroactive.
+
+## Contributing
+
+Issues, fixes, new ATS connectors, evidence rules, country coverage, tests, and documentation improvements are welcome.
+
+Because the project supports dual licensing, contributors should read the contribution-licensing terms before submitting code: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Support the project
+
+If Career Radar saves you time or helps you find a realistic opportunity, the easiest ways to support it are to **star the repository, share it with other international candidates, report bad sponsorship signals, and contribute verified improvements**.
+
+Organizations that want to support ongoing development, infrastructure, new country coverage, or public-data maintenance can discuss **project sponsorship or partnership** with the maintainer.
+
+Commercial licensing and sponsorship are separate: sponsorship supports the project; commercial rights require a written commercial license.
+
+## Maintainer
+
+**Mahdi Navaei** — [GitHub](https://github.com/MahdiNavaei)
+
+For commercial licensing, partnerships, or project sponsorship, use the contact information published on the maintainer's GitHub profile.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.1.4"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "PolyForm-Noncommercial-1.0.0" }
 authors = [{ name = "Mahdi Navaei" }]
 dependencies = [
   "alembic>=1.14,<2",


### PR DESCRIPTION
## Summary

This PR changes the project from MIT to a source-available dual-licensing model and refreshes the GitHub landing page without touching runtime or release workflow code.

### Licensing
- adopt `PolyForm-Noncommercial-1.0.0`
- add required attribution notices preserving Mahdi Navaei and the original repository
- add `COMMERCIAL_LICENSE.md` for commercial-use inquiries
- explicitly preserve the rights attached to earlier MIT-published versions
- align `pyproject.toml` and `DATA_LICENSES.md`
- add contribution licensing terms so future contributions remain compatible with commercial dual licensing
- protect licensing-sensitive files through CODEOWNERS

### README
- clearer product-first introduction and value proposition
- CI/license/platform badges
- simplified sponsorship evidence and eligibility model
- improved Windows, live-data, architecture, verification, and developer sections
- preserve the v1.1.4 signed/unsigned release-mode truth and SHA-256 guidance
- clear source-available / commercial-use language
- subtle project sponsorship and partnership CTA

## Release safety

This branch was rebuilt on top of the completed `v1.1.4` release HEAD `77173cd4c1e8ca51bbc904d409805145c356c200`, so the final release-engineering fixes are preserved.

No runtime application code or GitHub Actions workflow is changed by this PR.