### PR TITLE
fix: fetch durable catalog for tagged Windows builds

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -81,7 +81,10 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force build/windows/app | Out-Null
           New-Item -ItemType Directory -Force build/windows/catalog | Out-Null
-          git fetch origin market-data 2>$null
+          git fetch --no-tags origin "refs/heads/market-data:refs/remotes/origin/market-data"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to fetch the durable market-data branch for the Windows package."
+          }
           if (git cat-file -e origin/market-data:data/catalog/latest.json 2>$null) {
             $manifest = git show origin/market-data:data/catalog/latest.json | ConvertFrom-Json
             $payload = [IO.Path]::GetFileName($manifest.payload)

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -81,6 +81,7 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "sqlite:///./source-health.sqlite" not in health
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
+    assert 'git fetch --no-tags origin "refs/heads/market-data:refs/remotes/origin/market-data"' in windows
     assert "--only-uningested --largest-first --limit 100" in daily
     assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily


### PR DESCRIPTION
## Summary\n- fetch market-data with an explicit remote refspec in Windows packaging\n- fail visibly if the durable catalog branch cannot be fetched\n- add regression coverage for the tagged-build fetch contract\n\nThe previous v1.1.4 tag run failed before packaging because the implicit fetch did not expose origin/market-data in the tagged checkout.