### PR TITLE
fix: detect published catalog in tagged builds

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -85,10 +85,13 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Unable to fetch the durable market-data branch for the Windows package."
           }
-          if (git cat-file -e origin/market-data:data/catalog/latest.json 2>$null) {
-            $manifest = git show origin/market-data:data/catalog/latest.json | ConvertFrom-Json
+          $catalogManifest = "origin/market-data:data/catalog/latest.json"
+          git cat-file -e $catalogManifest 2>$null
+          $hasCatalog = ($LASTEXITCODE -eq 0)
+          if ($hasCatalog) {
+            $manifest = git show $catalogManifest | ConvertFrom-Json
             $payload = [IO.Path]::GetFileName($manifest.payload)
-            git show "origin/market-data:data/catalog/latest.json" | Set-Content -Encoding utf8 build/windows/catalog/latest.json
+            git show $catalogManifest | Set-Content -Encoding utf8 build/windows/catalog/latest.json
             git show "origin/market-data:data/catalog/$payload" > "build/windows/catalog/$payload"
             Write-Host "Bundled published market catalog $payload"
           } else {

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -327,6 +327,7 @@ jobs:
           $env:CAREERRADAR_DATA_DIR = $smokeDataDir
           $env:CAREERRADAR_SMOKE_SEED = "1"
           $env:CAREERRADAR_REQUIRE_BUNDLED_CATALOG = "1"
+          $env:CAREERRADAR_SMOKE_BOUNDED_CATALOG = "1"
           try {
             $installedSmoke = Start-Process -FilePath "$installDir/CareerRadar.exe" -ArgumentList "--smoke-test" -WindowStyle Hidden -Wait -PassThru
             if ($installedSmoke.ExitCode -ne 0) {
@@ -357,6 +358,7 @@ jobs:
             Remove-Item Env:CAREERRADAR_DATA_DIR -ErrorAction SilentlyContinue
             Remove-Item Env:CAREERRADAR_SMOKE_SEED -ErrorAction SilentlyContinue
             Remove-Item Env:CAREERRADAR_REQUIRE_BUNDLED_CATALOG -ErrorAction SilentlyContinue
+            Remove-Item Env:CAREERRADAR_SMOKE_BOUNDED_CATALOG -ErrorAction SilentlyContinue
           }
 
       - name: Verify two market-data cycles through the same installed runtime

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -65,7 +65,10 @@ installation and a freshly extracted portable directory with host Python and Nod
 removed from `PATH`. The test uses an isolated data directory and one clearly
 fictional fixture so it can verify migrations, the API, the production web server,
 the frontend response, and clean child-process shutdown without making a live ATS
-network call.
+network call. It also validates the bundled market-catalog manifest, compressed
+payload, SHA-256, gzip, and schema without bulk-importing the full published dataset
+into the smoke-test SQLite database. The separate two-cycle market-data smoke test
+exercises the full import/update path with a bounded fixture.
 
 ## Portable package
 

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -529,24 +529,30 @@ def smoke_test(data_dir: Path) -> int:
         if missing_resources:
             raise RuntimeError("Embedded runtime resources are missing: " + ", ".join(missing_resources))
         if os.environ.get("CAREERRADAR_REQUIRE_BUNDLED_CATALOG") == "1":
-            from sqlalchemy import func, select
-
-            from europe_visa_jobs.catalog import import_catalog
-            from europe_visa_jobs.db.locking import database_write_lock
-            from europe_visa_jobs.db.models import Job
-            from europe_visa_jobs.db.session import SessionLocal
-
             bundled_manifest = bundle_dir() / "catalog" / "latest.json"
             if not bundled_manifest.exists():
                 raise RuntimeError("The Windows package does not contain a published market catalog.")
-            with database_write_lock(os.environ["DATABASE_URL"]), SessionLocal() as session:
-                import_catalog(session, bundled_manifest)
-                session.commit()
-                bundled_jobs = session.scalar(
-                    select(func.count()).select_from(Job).where(Job.active.is_(True))
-                ) or 0
-            if bundled_jobs < 1:
-                raise RuntimeError("The bundled market catalog contains no active jobs.")
+            if os.environ.get("CAREERRADAR_SMOKE_BOUNDED_CATALOG") == "1":
+                from europe_visa_jobs.catalog import validate_catalog
+
+                validate_catalog(bundled_manifest)
+                print("Bundled market catalog manifest and payload validated.")
+            else:
+                from sqlalchemy import func, select
+
+                from europe_visa_jobs.catalog import import_catalog
+                from europe_visa_jobs.db.locking import database_write_lock
+                from europe_visa_jobs.db.models import Job
+                from europe_visa_jobs.db.session import SessionLocal
+
+                with database_write_lock(os.environ["DATABASE_URL"]), SessionLocal() as session:
+                    import_catalog(session, bundled_manifest)
+                    session.commit()
+                    bundled_jobs = session.scalar(
+                        select(func.count()).select_from(Job).where(Job.active.is_(True))
+                    ) or 0
+                if bundled_jobs < 1:
+                    raise RuntimeError("The bundled market catalog contains no active jobs.")
         if os.environ.get("CAREERRADAR_SMOKE_SEED") == "1":
             seed_smoke_data()
         if os.environ.get("CAREERRADAR_SMOKE_SYNC") == "1":

--- a/scripts/windows_market_cycle_smoke.py
+++ b/scripts/windows_market_cycle_smoke.py
@@ -81,6 +81,9 @@ def _run(executable: Path, data_dir: Path, manifest_url: str, *, require_bundle:
             "CAREERRADAR_CATALOG_MANIFEST_URL": manifest_url,
             "CAREERRADAR_ALLOW_LOCAL_CATALOG_TEST": "1",
             "CAREERRADAR_SMOKE_SYNC": "1",
+            # Validate the packaged durable catalog without bulk-importing it;
+            # the downloaded N/N+1 fixtures below still exercise full import.
+            "CAREERRADAR_SMOKE_BOUNDED_CATALOG": "1",
         }
     )
     if require_bundle:

--- a/src/europe_visa_jobs/catalog/__init__.py
+++ b/src/europe_visa_jobs/catalog/__init__.py
@@ -5,6 +5,7 @@ from europe_visa_jobs.catalog.delivery import (
     import_catalog,
     publish_catalog,
     sync_catalog,
+    validate_catalog,
 )
 
-__all__ = ["CatalogManifest", "import_catalog", "publish_catalog", "sync_catalog"]
+__all__ = ["CatalogManifest", "import_catalog", "publish_catalog", "sync_catalog", "validate_catalog"]

--- a/src/europe_visa_jobs/catalog/delivery.py
+++ b/src/europe_visa_jobs/catalog/delivery.py
@@ -163,14 +163,13 @@ def publish_catalog(session: Session, output_dir: str | Path, *, dataset_version
     return manifest
 
 
-def import_catalog(
-    session: Session,
+def _load_catalog_payload(
     manifest_path: str | Path,
     *,
     max_bytes: int = MAX_COMPRESSED_BYTES,
     max_uncompressed_bytes: int = MAX_UNCOMPRESSED_BYTES,
-) -> CatalogManifest:
-    """Verify a data-only snapshot and apply it in the caller's transaction."""
+) -> tuple[CatalogManifest, dict[str, Any]]:
+    """Verify and decode a data-only snapshot without changing the database."""
     manifest_file = Path(manifest_path)
     manifest_data = _read_json_file_bounded(manifest_file, MAX_MANIFEST_BYTES)
     try:
@@ -196,6 +195,37 @@ def import_catalog(
         or not isinstance(payload.get("jobs"), list)
     ):
         raise ValueError("catalog payload schema mismatch")
+    return manifest, payload
+
+
+def validate_catalog(
+    manifest_path: str | Path,
+    *,
+    max_bytes: int = MAX_COMPRESSED_BYTES,
+    max_uncompressed_bytes: int = MAX_UNCOMPRESSED_BYTES,
+) -> CatalogManifest:
+    """Validate a catalog snapshot without importing its rows into the database."""
+    manifest, _ = _load_catalog_payload(
+        manifest_path,
+        max_bytes=max_bytes,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+    )
+    return manifest
+
+
+def import_catalog(
+    session: Session,
+    manifest_path: str | Path,
+    *,
+    max_bytes: int = MAX_COMPRESSED_BYTES,
+    max_uncompressed_bytes: int = MAX_UNCOMPRESSED_BYTES,
+) -> CatalogManifest:
+    """Verify a data-only snapshot and apply it in the caller's transaction."""
+    manifest, payload = _load_catalog_payload(
+        manifest_path,
+        max_bytes=max_bytes,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+    )
     catalog_source_keys: set[tuple[str, str]] = set()
     for source in payload.get("sources", []):
         if source.get("provider") and source.get("board_identifier"):

--- a/tests/test_catalog_delivery.py
+++ b/tests/test_catalog_delivery.py
@@ -11,7 +11,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 import europe_visa_jobs.catalog.delivery as delivery
-from europe_visa_jobs.catalog.delivery import import_catalog, publish_catalog, sync_catalog
+from europe_visa_jobs.catalog.delivery import (
+    import_catalog,
+    publish_catalog,
+    sync_catalog,
+    validate_catalog,
+)
 from europe_visa_jobs.db.models import Base, CandidateJobState, Job
 from europe_visa_jobs.db.repository import Repository
 from europe_visa_jobs.db.source_registry import SourceRegistry
@@ -51,6 +56,8 @@ def test_catalog_manifest_is_hash_verified_and_atomic(db_session, tmp_path: Path
     assert manifest.sha256
     assert json.loads((tmp_path / "latest.json").read_text())['payload'] == "catalog-n1.json.gz"
 
+    validated = validate_catalog(tmp_path / "latest.json")
+    assert validated.dataset_version == "n1"
     import_catalog(db_session, tmp_path / "latest.json")
 
     tampered = bytearray((tmp_path / manifest.payload).read_bytes())

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -84,6 +84,7 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert 'git fetch --no-tags origin "refs/heads/market-data:refs/remotes/origin/market-data"' in windows
     assert '$hasCatalog = ($LASTEXITCODE -eq 0)' in windows
     assert 'if ($hasCatalog)' in windows
+    assert 'CAREERRADAR_SMOKE_BOUNDED_CATALOG' in windows
     assert "--only-uningested --largest-first --limit 100" in daily
     assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -82,6 +82,8 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "validate_release_inputs.py --require-snapshot --require-input-hashes" in windows
     assert "windows_market_cycle_smoke.py" in windows
     assert 'git fetch --no-tags origin "refs/heads/market-data:refs/remotes/origin/market-data"' in windows
+    assert '$hasCatalog = ($LASTEXITCODE -eq 0)' in windows
+    assert 'if ($hasCatalog)' in windows
     assert "--only-uningested --largest-first --limit 100" in daily
     assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -85,6 +85,8 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert '$hasCatalog = ($LASTEXITCODE -eq 0)' in windows
     assert 'if ($hasCatalog)' in windows
     assert 'CAREERRADAR_SMOKE_BOUNDED_CATALOG' in windows
+    cycle_smoke = (root / "scripts" / "windows_market_cycle_smoke.py").read_text(encoding="utf-8")
+    assert '"CAREERRADAR_SMOKE_BOUNDED_CATALOG": "1"' in cycle_smoke
     assert "--only-uningested --largest-first --limit 100" in daily
     assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily


### PR DESCRIPTION
## Summary\n- evaluate git cat-file by exit code in the Windows packaging workflow\n- allow tagged builds to consume the existing market-data latest manifest\n- add regression assertions for the PowerShell condition\n\nThe previous tagged run fetched market-data successfully but treated the no-output cat-file probe as false.