### PR TITLE
Fix recurring refresh of previously ingested job sources

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -1,8 +1,11 @@
-name: Daily ingestion
+name: Recurring catalog ingestion
 
 on:
   schedule:
-    - cron: "17 4 * * *"
+    # An hourly bounded run gives the current 771-source verified registry
+    # enough reserved recurring-refresh capacity to revisit healthy boards in
+    # approximately 25 hours, even while new-board coverage is also pending.
+    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -21,6 +24,8 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       PYTHONPATH: src:.
+      INGESTION_REFRESH_INTERVAL_HOURS: "18"
+      INGESTION_REFRESH_STALE_SHARE: "0.75"
 
     steps:
       - name: Checkout
@@ -70,10 +75,29 @@ jobs:
       - name: Validate authoritative source snapshot
         run: |
           python - <<'PY'
+          from math import ceil
           from europe_visa_jobs.ingestion.sources import load_sources
           sources = load_sources("build/source-registry.latest.json", minimum_snapshot_sources=500)
           assert all("example" not in source.slug.lower() for source in sources)
-          print(f"validated {len(sources)} live ATS sources")
+          batch_size = 150
+          refresh_interval_hours = 18
+          max_revisit_hours = 25
+          recurring_slots = ceil(batch_size * 0.75)
+          recurring_capacity = refresh_interval_hours * recurring_slots
+          assert len(sources) <= recurring_capacity, (
+              f"verified registry has {len(sources)} boards but the configured "
+              f"18-hour fairness window reserves only {recurring_capacity} refresh slots"
+          )
+          worst_case_hours = refresh_interval_hours + ceil(len(sources) / recurring_slots)
+          assert worst_case_hours <= max_revisit_hours, (
+              f"verified registry growth makes the documented {max_revisit_hours}-hour "
+              f"revisit bound impossible: {len(sources)} boards require approximately "
+              f"{worst_case_hours} hours with {recurring_slots} reserved slots/run"
+          )
+          print(
+              f"validated {len(sources)} live ATS sources; recurring capacity="
+              f"{recurring_capacity} boards/18h, bounded revisit≈{worst_case_hours}h"
+          )
           PY
 
       - name: Migrate database
@@ -87,8 +111,8 @@ jobs:
           evj-ingest sources bootstrap --snapshot build/source-registry.latest.json --config config/sources.json
           evj-ingest sources discover --mode recent --method manual --limit 100
 
-      - name: Ingest a durable registry batch
-        run: evj-ingest jobs --registry --only-uningested --largest-first --limit 100 --allow-partial --summary-file build/ingestion-summary.json
+      - name: Ingest a fair durable refresh batch
+        run: evj-ingest jobs --registry --due-for-refresh --limit 150 --allow-partial --summary-file build/ingestion-summary.json
 
       - name: Report persisted ingestion result
         run: |

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -403,7 +403,7 @@ jobs:
 
           The desktop runtime stores its local SQLite database under `%LOCALAPPDATA%\\CareerRadar`, refreshes live ATS feeds on first launch, and refreshes again when data is older than 24 hours while the launcher is running.
 
-          Career Radar refreshes configured sources daily and surfaces newly discovered eligible opportunities. This is evidence-based job intelligence, not legal advice and not a guarantee that an employer will sponsor a particular applicant or publish a new eligible vacancy every calendar day.
+          Career Radar's central scheduler revisits the current verified source registry within an approximately 25-hour bounded window and surfaces newly discovered eligible opportunities. Installed clients check the published catalog every 24 hours while running. This is evidence-based job intelligence, not legal advice and not a guarantee that an employer will sponsor a particular applicant or publish a new eligible vacancy in every refresh window.
 
           A portable ZIP and SHA-256 checksum file are included as well.
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ mode; see [Windows packaging](docs/WINDOWS.md) and the
 
 ## Live data and coverage
 
-Scheduled workflows refresh configured public ATS sources and publish a versioned
-catalog to the `market-data` branch. The catalog is compressed, SHA-256 verified,
-gzip/schema validated, staged, and atomically imported by clients. A failed update
-preserves the previous valid local catalog.
+Scheduled workflows revisit known public ATS boards and publish a versioned catalog
+to the `market-data` branch. Verified boards become due after 18 hours; an hourly,
+fair bounded scheduler gives the current registry an approximately 25-hour worst-case
+revisit window while reserving capacity for newly verified boards. The workflow
+refuses to claim that bound if registry growth exceeds its configured capacity. The
+catalog is compressed, SHA-256 verified, gzip/schema validated, staged, and atomically
+imported by clients. A failed update preserves the previous valid local catalog.
 
 Coverage describes monitored, verified sources—not every European employer or vacancy.
 A refreshed catalog does not guarantee a new eligible vacancy every day. Read the

--- a/docs/data-delivery.md
+++ b/docs/data-delivery.md
@@ -57,14 +57,29 @@ than being presented as a complete market census.
 Scheduled discovery and source health use `SOURCE_STATE_DATABASE_URL` when configured.
 Without that secret they restore, update, sanitize, and republish a durable SQLite
 checkpoint on the `market-data` branch; runner-local state alone is never treated as
-authoritative. Daily ingestion bootstraps the verified registry snapshot and loads
+authoritative. Recurring ingestion bootstraps the verified registry snapshot and loads
 `data/sponsors.csv.gz` before evaluating jobs.
 
 The source-discovery workflow publishes its latest verified registry to
-`market-data/source-registry.latest.json`. Daily ingestion consumes that publication
+`market-data/source-registry.latest.json`. Recurring ingestion consumes that publication
 before falling back to the checked-in bootstrap snapshot, so a newly verified board
 can enter the central job dataset and then reach existing desktop installations
 without a software reinstall.
+
+Central job ingestion runs hourly with a bounded batch of 150. Healthy boards become
+due 18 hours after their last successful ingestion. When new and previously-ingested
+boards are both waiting, at least 75% of each batch (113 slots) is reserved for the
+oldest due refreshes and the remaining slots advance first-ingestion coverage; unused
+capacity flows to the other partition. Retryable degraded/failing boards re-enter only
+after their backoff deadline. Ordering is deterministic by oldest ingestion/discovery
+time and provider identity.
+
+The checked-in production snapshot currently contains 771 verified boards. The
+reserved recurring capacity is therefore 18 × 113 = 2,034 board slots per 18-hour
+window, and draining all 771 simultaneously due boards takes at most seven hourly
+batches. The configured bound is consequently approximately 25 hours from one
+successful fetch to the next under normal healthy-run assumptions. The workflow has a
+capacity assertion so registry growth cannot silently make this statement false.
 
 The publication branch is rewritten as a single orphan snapshot under the shared
 `market-data-publication` concurrency lock. The catalog retains at most 14 compressed
@@ -85,7 +100,9 @@ promoted first and `latest.json` is replaced last, only after validation and dat
 import succeed. A failed update therefore leaves the previous valid cache and local
 candidate state intact.
 
-The update regression covers catalog versions N, N+1, and N+2. N+1 adds a source,
-adds a job, and changes a JD while preserving candidate tracking state. N+2 marks the
-source partial and omits a previously active job; the client retains that job instead
-of deactivating it.
+The update regressions use the same already-ingested source across versions N and
+N+1. They prove new eligible jobs and changed evidence reach an existing client while
+candidate, Saved, Applied, and notes state survive. Separate complete/partial provider
+cycles prove that authoritative removals propagate and partial omissions do not cause
+false deactivation. The packaged Windows runtime also exercises two catalog versions
+through one installed executable without reinstalling.

--- a/scripts/windows_market_cycle_smoke.py
+++ b/scripts/windows_market_cycle_smoke.py
@@ -19,11 +19,17 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from europe_visa_jobs.catalog.delivery import publish_catalog
-from europe_visa_jobs.db.models import Base, Job
+from europe_visa_jobs.db.models import Base, CandidateJobState, Job
 from europe_visa_jobs.db.repository import Repository
 from europe_visa_jobs.db.source_registry import SourceRegistry
 from europe_visa_jobs.eligibility import EligibilityEngine
-from europe_visa_jobs.schemas import ATSProvider, JobFamily, NormalizedJob, SourceConfig
+from europe_visa_jobs.schemas import (
+    ATSProvider,
+    CandidateCreate,
+    JobFamily,
+    NormalizedJob,
+    SourceConfig,
+)
 
 
 def _job(external_id: str, title: str) -> NormalizedJob:
@@ -114,6 +120,53 @@ def _active_jobs(data_dir: Path) -> dict[str, tuple[str, int]]:
     return {str(external_id): (str(title), int(active)) for external_id, title, active in rows}
 
 
+def _attach_local_state(data_dir: Path) -> int:
+    engine = create_engine(f"sqlite:///{(data_dir / 'career-radar.db').as_posix()}")
+    try:
+        with Session(engine) as session:
+            candidate = Repository(session).create_candidate(
+                CandidateCreate(
+                    name="Existing Installed User",
+                    target_roles=["Backend Engineer"],
+                    skills=["Python"],
+                    preferred_countries=["Germany"],
+                )
+            )
+            job = session.query(Job).filter_by(source_slug="cycle-smoke", external_id="one").one()
+            session.add(
+                CandidateJobState(
+                    candidate_id=candidate.id,
+                    job_id=job.id,
+                    saved=True,
+                    application_status="applied",
+                    note="Persist across catalog refresh",
+                )
+            )
+            session.commit()
+            return candidate.id
+    finally:
+        engine.dispose()
+
+
+def _assert_local_state(data_dir: Path, candidate_id: int) -> None:
+    engine = create_engine(f"sqlite:///{(data_dir / 'career-radar.db').as_posix()}")
+    try:
+        with Session(engine) as session:
+            candidate = Repository(session).get_candidate(candidate_id)
+            if candidate is None or candidate.name != "Existing Installed User":
+                raise RuntimeError("N+1 catalog sync did not preserve the installed candidate profile")
+            changed_job = session.query(Job).filter_by(
+                source_slug="cycle-smoke", external_id="one"
+            ).one()
+            tracking = session.query(CandidateJobState).filter_by(
+                candidate_id=candidate_id, job_id=changed_job.id
+            ).one()
+            if not tracking.saved or tracking.application_status != "applied" or tracking.note != "Persist across catalog refresh":
+                raise RuntimeError("N+1 catalog sync did not preserve Saved/Applied/notes state")
+    finally:
+        engine.dispose()
+
+
 def run(executable: Path) -> None:
     root = Path(tempfile.mkdtemp(prefix="career-radar-market-cycle-"))
     _build_catalogs(root)
@@ -131,6 +184,7 @@ def run(executable: Path) -> None:
         first_jobs = _active_jobs(data_dir)
         if set(first_jobs) != {"one", "two"}:
             raise RuntimeError(f"N did not install the expected jobs: {first_jobs!r}")
+        candidate_id = _attach_local_state(data_dir)
 
         _run(executable, data_dir, f"{base_url}/n1/latest.json", require_bundle=False)
         second_state = json.loads((data_dir / "last-refresh.json").read_text(encoding="utf-8"))
@@ -141,6 +195,7 @@ def run(executable: Path) -> None:
             raise RuntimeError(f"N+1 did not install the new/edited jobs: {second_jobs!r}")
         if second_jobs.get("two", ("", 1))[1] != 0:
             raise RuntimeError(f"N+1 did not close the removed job: {second_jobs!r}")
+        _assert_local_state(data_dir, candidate_id)
         print("Windows installed runtime market-data cycles N -> N+1 passed without reinstall.")
     finally:
         server.shutdown()

--- a/src/europe_visa_jobs/db/source_registry.py
+++ b/src/europe_visa_jobs/db/source_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import UTC, datetime, timedelta
+from math import ceil
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
@@ -171,14 +172,35 @@ class SourceRegistry:
             parsed = datetime.fromisoformat(value)
             return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
 
-        source = self.import_config(config)
         last_success = parse_timestamp(health.get("last_success_at"))
         if last_success is None:
             raise ValueError("snapshot source is missing last_success_at")
+        incoming_checked_at = parse_timestamp(health.get("last_checked_at")) or last_success
+
+        # The discovery snapshot and central ingestion checkpoint are produced
+        # by separate scheduled workflows. Re-importing an older discovery
+        # snapshot must not erase a newer ingestion failure/backoff decision or
+        # re-enable a source before its retry deadline.
+        from europe_visa_jobs.discovery.patterns import identify_config
+
+        identified = identify_config(config)
+        existing = self.get(config.provider, identified.board_identifier)
+        previous_enabled = existing.enabled if existing is not None else None
+        local_checked_at = existing.last_checked_at if existing is not None else None
+        if local_checked_at is not None and local_checked_at.tzinfo is None:
+            local_checked_at = local_checked_at.replace(tzinfo=UTC)
+
+        source = self.import_config(config)
+        if local_checked_at is not None and local_checked_at > incoming_checked_at:
+            if previous_enabled is not None:
+                source.enabled = previous_enabled
+            self.session.flush()
+            return source
+
         source.validation_state = SourceValidationState.VERIFIED.value
         source.status = str(health.get("health_state") or SourceStatus.HEALTHY.value)
         source.verified_at = source.verified_at or last_success
-        source.last_checked_at = parse_timestamp(health.get("last_checked_at")) or last_success
+        source.last_checked_at = incoming_checked_at
         source.last_health_check_at = source.last_checked_at
         source.last_success_at = last_success
         source.last_failure_at = parse_timestamp(health.get("last_failure_at"))
@@ -370,6 +392,78 @@ class SourceRegistry:
         if limit:
             stmt = stmt.limit(limit)
         return list(self.session.scalars(stmt))
+
+    def due_for_ingestion(
+        self,
+        *,
+        refresh_interval: timedelta,
+        now: datetime | None = None,
+        providers: set[str] | None = None,
+        limit: int | None = None,
+        stale_share: float = 0.75,
+    ) -> list[Source]:
+        """Return a deterministic, starvation-resistant scheduled refresh batch.
+
+        Never-ingested verified boards and previously-ingested boards whose
+        refresh interval elapsed share the same bounded batch. A reserved stale
+        share prevents a large discovery backlog from starving recurring
+        refreshes; the remainder guarantees that new boards continue to enter
+        coverage. Unused capacity from either partition is filled by the other.
+        """
+        if refresh_interval <= timedelta(0):
+            raise ValueError("refresh_interval must be positive")
+        if not 0 < stale_share < 1:
+            raise ValueError("stale_share must be between zero and one")
+        if limit is not None and limit < 1:
+            return []
+
+        current = now or datetime.now(UTC)
+        cutoff = current - refresh_interval
+        retrying_statuses = {
+            SourceStatus.DEGRADED.value,
+            SourceStatus.FAILING.value,
+        }
+        stmt = select(Source).where(
+            Source.verified_at.is_not(None),
+            or_(Source.enabled.is_(True), Source.status.in_(retrying_statuses)),
+            or_(Source.last_ingested_at.is_(None), Source.last_ingested_at <= cutoff),
+            or_(
+                Source.status.not_in(retrying_statuses),
+                Source.retry_after.is_(None),
+                Source.retry_after <= current,
+            ),
+        )
+        if providers:
+            stmt = stmt.where(Source.provider.in_(providers))
+        candidates = list(self.session.scalars(stmt))
+
+        never = sorted(
+            (source for source in candidates if source.last_ingested_at is None),
+            key=lambda source: (source.discovered_at, source.provider, source.board_identifier),
+        )
+        stale = sorted(
+            (source for source in candidates if source.last_ingested_at is not None),
+            key=lambda source: (source.last_ingested_at, source.provider, source.board_identifier),
+        )
+        if limit is None or len(candidates) <= limit:
+            return stale + never
+        if not stale:
+            return never[:limit]
+        if not never:
+            return stale[:limit]
+
+        stale_slots = min(len(stale), max(1, ceil(limit * stale_share)))
+        never_slots = min(len(never), max(1, limit - stale_slots))
+        selected = stale[:stale_slots] + never[:never_slots]
+        remaining = limit - len(selected)
+        if remaining:
+            # One partition can be smaller than its reservation. Fill the
+            # unused slots deterministically without wasting scheduler capacity.
+            selected.extend(stale[stale_slots : stale_slots + remaining])
+            remaining = limit - len(selected)
+        if remaining:
+            selected.extend(never[never_slots : never_slots + remaining])
+        return selected
 
     def coverage(self) -> dict[str, int | datetime | None]:
         sources = self.list_sources()

--- a/src/europe_visa_jobs/ingestion/cli.py
+++ b/src/europe_visa_jobs/ingestion/cli.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 from contextlib import nullcontext
+from datetime import timedelta
 from pathlib import Path
 
 import httpx
@@ -31,6 +32,7 @@ def _parser() -> argparse.ArgumentParser:
     jobs.add_argument("--sources", help="Path to source JSON")
     jobs.add_argument("--registry", action="store_true", help="Ingest verified enabled registry sources")
     jobs.add_argument("--only-uningested", action="store_true", help="Resume with verified boards not yet successfully ingested")
+    jobs.add_argument("--due-for-refresh", action="store_true", help="Ingest a fair batch of new and interval-due verified boards")
     jobs.add_argument("--provider", action="append", choices=[provider.value for provider in ATSProvider], help="Limit registry ingestion to one or more providers")
     jobs.add_argument("--limit", type=int, default=None, help="Limit registry sources")
     jobs.add_argument("--largest-first", action="store_true", help="Prioritize verified un-ingested boards with the most recently observed jobs")
@@ -90,6 +92,7 @@ async def _ingest(
     *,
     registry_mode: bool = False,
     only_uningested: bool = False,
+    due_for_refresh: bool = False,
     providers: set[str] | None = None,
     limit: int | None = None,
     largest_first: bool = False,
@@ -100,15 +103,27 @@ async def _ingest(
     if registry_mode:
         with SessionLocal() as session:
             registry = SourceRegistry(session)
-            items = registry.un_ingested_verified_sources(
-                providers=providers,
-                limit=limit,
-                largest_first=largest_first,
-            ) if only_uningested else registry.list_sources(
-                verified_only=True,
-                statuses={"healthy", "degraded", "failing", "empty"},
-                limit=limit,
-            )
+            if only_uningested and due_for_refresh:
+                raise RuntimeError("--only-uningested and --due-for-refresh are mutually exclusive")
+            if due_for_refresh:
+                items = registry.due_for_ingestion(
+                    providers=providers,
+                    limit=limit,
+                    refresh_interval=timedelta(hours=settings.ingestion_refresh_interval_hours),
+                    stale_share=settings.ingestion_refresh_stale_share,
+                )
+            elif only_uningested:
+                items = registry.un_ingested_verified_sources(
+                    providers=providers,
+                    limit=limit,
+                    largest_first=largest_first,
+                )
+            else:
+                items = registry.list_sources(
+                    verified_only=True,
+                    statuses={"healthy", "degraded", "failing", "empty"},
+                    limit=limit,
+                )
             sources = [registry.to_config(item) for item in items if providers is None or item.provider in providers]
     else:
         if not path:
@@ -139,6 +154,8 @@ async def _ingest(
             failures.append(label)
             print(f"{label} fetched=0 stored=0 status=failed error={str(error)[:300]}")
     summary: dict[str, object] = {
+        "selection_mode": "due_for_refresh" if due_for_refresh else "only_uningested" if only_uningested else "all",
+        "refresh_interval_hours": settings.ingestion_refresh_interval_hours if due_for_refresh else None,
         "sources_total": len(results),
         "sources_successful": successful,
         "sources_failed": len(failures),
@@ -208,6 +225,7 @@ def _run(args: argparse.Namespace) -> None:
                 args.sources,
                 registry_mode=args.registry,
                 only_uningested=args.only_uningested,
+                due_for_refresh=args.due_for_refresh,
                 providers=set(args.provider) if args.provider else None,
                 limit=args.limit,
                 largest_first=args.largest_first,

--- a/src/europe_visa_jobs/ingestion/pipeline.py
+++ b/src/europe_visa_jobs/ingestion/pipeline.py
@@ -59,6 +59,18 @@ async def ingest_source(
                     metadata={"duration_ms": fetch_duration_ms, "not_modified": True},
                 ),
             )
+            # A conditional 304 is a successful refresh. Advance the ingestion
+            # clock so this source does not remain due and consume every later
+            # bounded scheduler batch.
+            registry.record_ingestion_counts(
+                registry_source,
+                raw_jobs=registry_source.raw_job_count,
+                technical_jobs=registry_source.technical_job_count,
+                active_jobs=registry_source.active_job_count,
+                eligible_jobs=registry_source.eligible_job_count,
+                unknown_jobs=registry_source.unknown_job_count,
+                rejected_jobs=registry_source.rejected_job_count,
+            )
             run.fetched_count = registry_source.raw_job_count
             run.stored_count = registry_source.technical_job_count
             run.status = "success"

--- a/src/europe_visa_jobs/settings.py
+++ b/src/europe_visa_jobs/settings.py
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     discovery_user_agent: str = "CareerRadar/1.0 (+https://github.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs)"
     discovery_contact: str | None = None
     ingestion_concurrency: int = 4
+    # Central ingestion revisits healthy boards after this interval. The hosted
+    # scheduler reserves most bounded batch slots for already-ingested due
+    # boards while still advancing first-ingestion coverage.
+    ingestion_refresh_interval_hours: int = 18
+    ingestion_refresh_stale_share: float = 0.75
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="", extra="ignore")
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC
 from types import SimpleNamespace
 
 import httpx
@@ -8,6 +9,7 @@ import pytest
 
 import europe_visa_jobs.ingestion.cli as ingestion_cli
 import europe_visa_jobs.ingestion.pipeline as pipeline
+from europe_visa_jobs.connectors.base import ConnectorNotModified
 from europe_visa_jobs.db.models import IngestionRun
 from europe_visa_jobs.db.repository import Repository
 from europe_visa_jobs.schemas import ATSProvider, NormalizedJob, SourceConfig
@@ -106,6 +108,40 @@ async def test_failed_refresh_does_not_deactivate_previous_jobs(db_session, monk
 
 
 @pytest.mark.asyncio
+async def test_not_modified_refresh_advances_ingestion_clock(db_session, monkeypatch):
+    source = SourceConfig(provider="greenhouse", company_name="Acme", slug="acme", default_country="Germany")
+    monkeypatch.setattr(pipeline, "build_connector", lambda client, source: FakeConnector())
+    async with httpx.AsyncClient() as client:
+        await pipeline.ingest_source(db_session, source, client=client)
+
+    registry_source = __import__(
+        "europe_visa_jobs.db.source_registry", fromlist=["SourceRegistry"]
+    ).SourceRegistry(db_session).get("greenhouse", "acme")
+    assert registry_source is not None
+    previous = registry_source.last_ingested_at
+
+    class NotModifiedConnector:
+        def __init__(self):
+            self.last_response_headers = {"etag": '"same"'}
+            self.last_fetch_duration_ms = 3
+
+        async def fetch_jobs(self):
+            raise ConnectorNotModified("not modified", status_code=304, category="not_modified")
+
+    monkeypatch.setattr(pipeline, "build_connector", lambda client, source: NotModifiedConnector())
+    async with httpx.AsyncClient() as client:
+        await pipeline.ingest_source(db_session, source, client=client)
+
+    assert registry_source.last_ingested_at is not None
+    assert previous is not None
+    refreshed_at = registry_source.last_ingested_at
+    assert refreshed_at.replace(tzinfo=refreshed_at.tzinfo or UTC) >= previous.replace(
+        tzinfo=previous.tzinfo or UTC
+    )
+    assert Repository(db_session).list_jobs()[0].active is True
+
+
+@pytest.mark.asyncio
 async def test_successful_refresh_closes_and_reactivates_jobs_without_duplicates(db_session, monkeypatch):
     source = SourceConfig(provider="greenhouse", company_name="Acme", slug="acme", default_country="Germany")
     snapshots = [
@@ -195,6 +231,8 @@ async def test_ingestion_batch_continues_after_one_source_fails(monkeypatch, tmp
     )
     assert processed == ["broken", "healthy"]
     assert summary == {
+        "selection_mode": "all",
+        "refresh_interval_hours": None,
         "sources_total": 2,
         "sources_successful": 1,
         "sources_failed": 1,

--- a/tests/test_recurring_catalog_refresh.py
+++ b/tests/test_recurring_catalog_refresh.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+import europe_visa_jobs.ingestion.cli as ingestion_cli
+import europe_visa_jobs.ingestion.pipeline as pipeline
+from europe_visa_jobs.api.app import app
+from europe_visa_jobs.catalog.delivery import publish_catalog, sync_catalog
+from europe_visa_jobs.db.models import Base, CandidateJobState, Job
+from europe_visa_jobs.db.repository import Repository
+from europe_visa_jobs.db.session import get_db
+from europe_visa_jobs.db.source_registry import SourceRegistry
+from europe_visa_jobs.schemas import (
+    ATSProvider,
+    CandidateCreate,
+    JobFamily,
+    NormalizedJob,
+    SourceConfig,
+)
+
+MANIFEST_URL = (
+    "https://raw.githubusercontent.com/MahdiNavaei/Europe-Visa-Sponsorship-Jobs/"
+    "market-data/data/catalog/latest.json"
+)
+
+
+def _job(external_id: str, *, title: str, description: str) -> NormalizedJob:
+    return NormalizedJob(
+        external_id=external_id,
+        provider=ATSProvider.GREENHOUSE,
+        source_slug="recurring-board",
+        company_name="Recurring Board GmbH",
+        title=title,
+        description=description,
+        location="Berlin, Germany",
+        country="Germany",
+        apply_url=f"https://boards.greenhouse.io/recurring-board/jobs/{external_id}",
+        posted_at=datetime(2026, 8, 26, 8, 0, tzinfo=UTC),
+        job_family=JobFamily.AI_ML,
+    )
+
+
+def _catalog_http_client(catalog_dir: Path) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = catalog_dir / Path(request.url.path).name
+        if not path.is_file():
+            return httpx.Response(404, request=request)
+        body = path.read_bytes()
+        return httpx.Response(
+            200,
+            content=body,
+            headers={"Content-Length": str(len(body))},
+            request=request,
+        )
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _prepare_verified_source(factory) -> None:
+    with factory() as session:
+        source = SourceRegistry(session).import_config(
+            SourceConfig(
+                provider=ATSProvider.GREENHOUSE,
+                company_name="Recurring Board GmbH",
+                slug="recurring-board",
+                default_country="Germany",
+                enabled=True,
+            )
+        )
+        source.enabled = True
+        source.status = "healthy"
+        source.validation_state = "verified"
+        source.verified_at = datetime.now(UTC) - timedelta(days=30)
+        session.commit()
+
+
+def _make_due(factory) -> None:
+    with factory() as session:
+        source = SourceRegistry(session).get("greenhouse", "recurring-board")
+        assert source is not None and source.last_ingested_at is not None
+        source.last_ingested_at = datetime.now(UTC) - timedelta(hours=19)
+        session.commit()
+
+
+async def _run_due_ingestion(monkeypatch, factory, state: dict[str, object]) -> dict[str, object]:
+    class FixtureConnector:
+        detail_completeness = "complete"
+
+        def __init__(self) -> None:
+            self.completeness = str(state["completeness"])
+            self.last_response_headers: dict[str, str] = {}
+            self.last_fetch_duration_ms = 1
+
+        async def fetch_jobs(self):
+            state["fetches"] = int(state["fetches"]) + 1
+            return list(state["jobs"])
+
+    monkeypatch.setattr(pipeline, "build_connector", lambda client, source: FixtureConnector())
+    monkeypatch.setattr(ingestion_cli, "SessionLocal", factory)
+    monkeypatch.setattr(
+        ingestion_cli,
+        "get_settings",
+        lambda: SimpleNamespace(
+            request_timeout_seconds=1,
+            ingestion_concurrency=1,
+            ingestion_refresh_interval_hours=18,
+            ingestion_refresh_stale_share=0.75,
+        ),
+    )
+    return await ingestion_cli._ingest(
+        None,
+        registry_mode=True,
+        due_for_refresh=True,
+        limit=150,
+    )
+
+
+def _client_factory(path: Path):
+    engine = create_engine(f"sqlite:///{path.as_posix()}")
+    Base.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+
+
+@pytest.mark.asyncio
+async def test_same_ingested_source_new_and_changed_job_reaches_existing_client(
+    session_factory, tmp_path: Path, monkeypatch
+) -> None:
+    _prepare_verified_source(session_factory)
+    state: dict[str, object] = {
+        "jobs": [
+            _job(
+                "job-a",
+                title="Machine Learning Engineer",
+                description="Candidates must already have work authorization; visa sponsorship is not available.",
+            )
+        ],
+        "completeness": "complete",
+        "fetches": 0,
+    }
+
+    first_summary = await _run_due_ingestion(monkeypatch, session_factory, state)
+    assert first_summary["sources_successful"] == 1
+    with session_factory() as central:
+        source = SourceRegistry(central).get("greenhouse", "recurring-board")
+        assert source is not None and source.last_ingested_at is not None
+        first = central.query(Job).filter_by(external_id="job-a").one()
+        assert first.eligibility_status == "rejected"
+        publish_catalog(central, tmp_path / "catalog", dataset_version="n")
+
+    client_engine, client_factory = _client_factory(tmp_path / "existing-client.sqlite")
+    with _catalog_http_client(tmp_path / "catalog") as http, client_factory() as client_session:
+        sync_catalog(client_session, MANIFEST_URL, tmp_path / "cache", client=http)
+        repo = Repository(client_session)
+        candidate = repo.create_candidate(
+            CandidateCreate(
+                name="Existing User",
+                target_roles=["Machine Learning Engineer"],
+                skills=["Python"],
+                preferred_countries=["Germany"],
+            )
+        )
+        client_job = client_session.query(Job).filter_by(external_id="job-a").one()
+        client_session.add(
+            CandidateJobState(
+                candidate_id=candidate.id,
+                job_id=client_job.id,
+                saved=True,
+                application_status="applied",
+                note="Keep this local note",
+            )
+        )
+        client_session.commit()
+        candidate_id = candidate.id
+
+    _make_due(session_factory)
+    state["jobs"] = [
+        _job(
+            "job-a",
+            title="Senior Machine Learning Engineer",
+            description="Visa sponsorship and relocation support are available. Python is required.",
+        ),
+        _job(
+            "job-b",
+            title="Machine Learning Platform Engineer",
+            description="We provide visa sponsorship and relocation support. Python is required.",
+        ),
+    ]
+    second_summary = await _run_due_ingestion(monkeypatch, session_factory, state)
+    assert second_summary["selection_mode"] == "due_for_refresh"
+    assert second_summary["sources_successful"] == 1
+    assert state["fetches"] == 2
+
+    with session_factory() as central:
+        assert central.query(Job).filter_by(external_id="job-a").count() == 1
+        changed = central.query(Job).filter_by(external_id="job-a").one()
+        added = central.query(Job).filter_by(external_id="job-b").one()
+        assert changed.title == "Senior Machine Learning Engineer"
+        assert changed.eligibility_status == "eligible"
+        assert added.eligibility_status == "eligible"
+        publish_catalog(central, tmp_path / "catalog", dataset_version="n-plus-one")
+
+    with _catalog_http_client(tmp_path / "catalog") as http, client_factory() as client_session:
+        sync_catalog(client_session, MANIFEST_URL, tmp_path / "cache", client=http)
+        candidate = Repository(client_session).get_candidate(candidate_id)
+        assert candidate is not None and candidate.name == "Existing User"
+        changed = client_session.query(Job).filter_by(external_id="job-a").one()
+        added = client_session.query(Job).filter_by(external_id="job-b").one()
+        assert changed.title == "Senior Machine Learning Engineer"
+        assert changed.eligibility_status == "eligible"
+        assert added.active and added.eligibility_status == "eligible"
+        tracking = client_session.query(CandidateJobState).filter_by(job_id=changed.id).one()
+        assert tracking.saved is True
+        assert tracking.application_status == "applied"
+        assert tracking.note == "Keep this local note"
+        client_session.commit()
+
+    def override_db():
+        with client_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        api = TestClient(app)
+        jobs = api.get("/api/v1/jobs", params={"query": "Machine Learning Platform"})
+        assert jobs.status_code == 200
+        assert [item["external_id"] for item in jobs.json()] == ["job-b"]
+        recommendations = api.get(f"/api/v1/recommendations/{candidate_id}")
+        assert recommendations.status_code == 200
+        assert "job-b" in {item["job"]["external_id"] for item in recommendations.json()}
+    finally:
+        app.dependency_overrides.clear()
+        client_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("second_completeness", "expected_active"),
+    [("complete", False), ("partial", True)],
+)
+async def test_due_refresh_preserves_provider_completeness_on_catalog_sync(
+    session_factory,
+    tmp_path: Path,
+    monkeypatch,
+    second_completeness: str,
+    expected_active: bool,
+) -> None:
+    _prepare_verified_source(session_factory)
+    state: dict[str, object] = {
+        "jobs": [
+            _job("job-a", title="Machine Learning Engineer", description="Visa sponsorship is available."),
+            _job("job-b", title="Data Platform Engineer", description="Visa sponsorship is available."),
+        ],
+        "completeness": "complete",
+        "fetches": 0,
+    }
+    await _run_due_ingestion(monkeypatch, session_factory, state)
+    with session_factory() as central:
+        publish_catalog(central, tmp_path / "catalog", dataset_version="n")
+
+    client_engine, client_factory = _client_factory(
+        tmp_path / f"client-{second_completeness}.sqlite"
+    )
+    with _catalog_http_client(tmp_path / "catalog") as http, client_factory() as client_session:
+        sync_catalog(client_session, MANIFEST_URL, tmp_path / "cache", client=http)
+        client_session.commit()
+        assert client_session.query(Job).filter_by(external_id="job-b").one().active
+
+    _make_due(session_factory)
+    state["jobs"] = [
+        _job("job-a", title="Machine Learning Engineer", description="Visa sponsorship is available.")
+    ]
+    state["completeness"] = second_completeness
+    await _run_due_ingestion(monkeypatch, session_factory, state)
+    assert state["fetches"] == 2
+    with session_factory() as central:
+        central_removed = central.query(Job).filter_by(external_id="job-b").one()
+        assert central_removed.active is expected_active
+        publish_catalog(central, tmp_path / "catalog", dataset_version="n-plus-one")
+
+    with _catalog_http_client(tmp_path / "catalog") as http, client_factory() as client_session:
+        sync_catalog(client_session, MANIFEST_URL, tmp_path / "cache", client=http)
+        assert client_session.query(Job).filter_by(external_id="job-b").one().active is expected_active
+        client_session.commit()
+    client_engine.dispose()

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+from math import ceil
 from pathlib import Path
 
 _SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_release_inputs.py"
@@ -87,7 +89,15 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert 'CAREERRADAR_SMOKE_BOUNDED_CATALOG' in windows
     cycle_smoke = (root / "scripts" / "windows_market_cycle_smoke.py").read_text(encoding="utf-8")
     assert '"CAREERRADAR_SMOKE_BOUNDED_CATALOG": "1"' in cycle_smoke
-    assert "--only-uningested --largest-first --limit 100" in daily
+    assert "--due-for-refresh --limit 150" in daily
+    assert 'cron: "17 * * * *"' in daily
+    assert 'INGESTION_REFRESH_INTERVAL_HOURS: "18"' in daily
+    assert 'INGESTION_REFRESH_STALE_SHARE: "0.75"' in daily
+    snapshot = json.loads((root / "config" / "source-registry.snapshot.json").read_text(encoding="utf-8"))
+    recurring_slots = ceil(150 * 0.75)
+    assert snapshot["verified_source_count"] <= 18 * recurring_slots
+    assert 18 + ceil(snapshot["verified_source_count"] / recurring_slots) <= 25
+    assert "worst_case_hours <= max_revisit_hours" in daily
     assert "git read-tree --empty" in daily
     assert "git add data/catalog data/state" in daily
     assert "git add -A" not in daily

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -334,6 +334,136 @@ def test_uningested_sources_can_prioritize_observed_job_volume(db_session):
     assert registry.un_ingested_verified_sources(largest_first=True) == [sources[1], sources[0]]
 
 
+def test_due_ingestion_scheduler_is_deterministic_fair_and_respects_backoff(db_session):
+    registry = SourceRegistry(db_session)
+    now = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+
+    def add_source(
+        identifier: str,
+        *,
+        ingested_at: datetime | None,
+        status: str = SourceStatus.HEALTHY.value,
+        enabled: bool = True,
+        retry_after: datetime | None = None,
+    ):
+        source = registry.upsert_candidate(
+            SourceCandidate(
+                provider=ATSProvider.GREENHOUSE,
+                board_identifier=identifier,
+                canonical_url=f"https://boards.greenhouse.io/{identifier}",
+                discovery_method="scheduler_test",
+            ),
+            enabled=enabled,
+        )
+        source.verified_at = now - timedelta(days=30)
+        source.status = status
+        source.validation_state = SourceValidationState.VERIFIED.value
+        source.last_ingested_at = ingested_at
+        source.retry_after = retry_after
+        return source
+
+    due = [
+        add_source(f"due-{index}", ingested_at=now - timedelta(hours=40 - index))
+        for index in range(6)
+    ]
+    never = [add_source(f"never-{index}", ingested_at=None) for index in range(12)]
+    recent = add_source("recent", ingested_at=now - timedelta(hours=2))
+    backed_off = add_source(
+        "backed-off",
+        ingested_at=now - timedelta(days=2),
+        status=SourceStatus.DEGRADED.value,
+        retry_after=now + timedelta(hours=1),
+    )
+    retry_due = add_source(
+        "retry-due",
+        ingested_at=now - timedelta(days=2),
+        status=SourceStatus.FAILING.value,
+        enabled=False,
+        retry_after=now - timedelta(minutes=1),
+    )
+    db_session.flush()
+
+    first = registry.due_for_ingestion(
+        refresh_interval=timedelta(hours=18),
+        now=now,
+        limit=4,
+        stale_share=0.75,
+    )
+    assert [source.board_identifier for source in first] == [
+        "retry-due",
+        "due-0",
+        "due-1",
+        "never-0",
+    ]
+    assert recent not in first
+    assert backed_off not in first
+
+    # Mark each bounded batch as processed and prove that both partitions make
+    # progress across repeated scheduler runs. The old last_ingested_at-NULL
+    # selector would never include any of the due sources above.
+    selected_ids: set[int] = set()
+    for _ in range(6):
+        batch = registry.due_for_ingestion(
+            refresh_interval=timedelta(hours=18),
+            now=now,
+            limit=4,
+            stale_share=0.75,
+        )
+        if not batch:
+            break
+        selected_ids.update(source.id for source in batch)
+        for source in batch:
+            source.last_ingested_at = now
+        db_session.flush()
+
+    assert {source.id for source in due} <= selected_ids
+    assert retry_due.id in selected_ids
+    assert {source.id for source in never} <= selected_ids
+
+
+def test_verified_snapshot_does_not_erase_newer_ingestion_backoff(db_session):
+    registry = SourceRegistry(db_session)
+    source = registry.import_verified_snapshot(
+        SourceConfig(
+            provider=ATSProvider.GREENHOUSE,
+            company_name="Backoff Co",
+            slug="backoff-co",
+            metadata={
+                "snapshot_health": {
+                    "validation_state": "verified",
+                    "health_state": "healthy",
+                    "last_success_at": "2026-08-24T10:00:00+00:00",
+                    "last_checked_at": "2026-08-24T10:00:00+00:00",
+                }
+            },
+        )
+    )
+    source.status = SourceStatus.FAILING.value
+    source.enabled = False
+    source.last_checked_at = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
+    source.retry_after = datetime(2026, 8, 26, 16, 0, tzinfo=UTC)
+    db_session.flush()
+
+    refreshed = registry.import_verified_snapshot(
+        SourceConfig(
+            provider=ATSProvider.GREENHOUSE,
+            company_name="Backoff Co",
+            slug="backoff-co",
+            metadata={
+                "snapshot_health": {
+                    "validation_state": "verified",
+                    "health_state": "healthy",
+                    "last_success_at": "2026-08-24T10:00:00+00:00",
+                    "last_checked_at": "2026-08-24T10:00:00+00:00",
+                }
+            },
+        )
+    )
+    assert refreshed.status == SourceStatus.FAILING.value
+    assert refreshed.enabled is False
+    assert refreshed.retry_after == datetime(2026, 8, 26, 16, 0, tzinfo=UTC)
+
+
 def test_two_scheduled_runs_retain_registry_state_and_skip_cached_candidates(db_session):
     registry = SourceRegistry(db_session)
     verified = registry.upsert_candidate(

--- a/tests/test_source_live_components.py
+++ b/tests/test_source_live_components.py
@@ -304,6 +304,11 @@ def test_jobs_cli_can_target_provider_for_bounded_ingestion():
     )
     assert args.provider == ["personio"] and args.only_uningested
 
+    due = ingestion_cli._parser().parse_args(
+        ["jobs", "--registry", "--due-for-refresh", "--limit", "150"]
+    )
+    assert due.due_for_refresh and due.limit == 150
+
 
 @pytest.mark.asyncio
 async def test_bounded_discovery_does_not_mark_unselected_verified_sources_pending(monkeypatch, db_session):

--- a/tests/test_windows_launcher.py
+++ b/tests/test_windows_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -108,6 +109,27 @@ def test_refresh_start_preserves_last_successful_sync(tmp_path: Path) -> None:
     assert during["last_successful_sync"] == before["last_successful_sync"]
     assert during["dataset_version"] == "2026-08-24"
     assert during["error"] is None
+
+
+def test_existing_install_refresh_due_uses_24_hour_interval(tmp_path: Path, monkeypatch) -> None:
+    launcher = load_launcher_module()
+    baseline = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    launcher.last_refresh_path(tmp_path).write_text(
+        launcher.json.dumps({"completed_at": baseline.isoformat()}),
+        encoding="utf-8",
+    )
+
+    class FrozenDateTime(datetime):
+        current = baseline + timedelta(hours=23, minutes=59)
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls.current if tz else cls.current.replace(tzinfo=None)
+
+    monkeypatch.setattr(launcher, "datetime", FrozenDateTime)
+    assert launcher.refresh_due(tmp_path) is False
+    FrozenDateTime.current = baseline + timedelta(hours=24)
+    assert launcher.refresh_due(tmp_path) is True
 
 
 def test_bundled_recovery_is_reported_as_stale_not_success(tmp_path: Path) -> None:


### PR DESCRIPTION
## Root cause
The scheduled central ingestion used `--only-uningested`, whose registry query required `last_ingested_at IS NULL`. A verified board dropped out of scheduled ingestion forever after its first successful fetch.

## Implementation
- Add deterministic `due_for_ingestion` selection for verified/enabled sources that are new or older than the 18-hour refresh interval.
- Reserve 75% of each bounded batch for oldest due refreshes and the remainder for never-ingested boards, with unused capacity shared, so neither partition can starve.
- Respect degraded/failing retry deadlines and preserve newer ingestion health/backoff state when an older discovery snapshot is imported.
- Treat HTTP 304 as a successful refresh and advance the ingestion clock.
- Run the central workflow hourly with batches of 150 and a capacity assertion tied to the documented SLA.
- Preserve existing complete/partial enumeration reconciliation and catalog/client atomic-sync behavior.
- Expand installed-runtime smoke coverage to preserve candidate, Saved, Applied, and notes state across catalog N -> N+1.

## Freshness SLA and capacity
Current verified snapshot: 771 boards. Each hourly run reserves `ceil(150 * 0.75) = 113` recurring slots. All simultaneously due healthy boards drain in `ceil(771 / 113) = 7` runs. With an 18-hour due interval, the normal bounded revisit is approximately `18 + 7 = 25` hours. The workflow fails if registry growth makes that documented bound impossible.

## Regression coverage
- Same already-ingested source adds a new eligible sponsorship job and changes an existing job/evidence.
- Published catalog reaches an existing client and normal jobs/recommendations APIs without reinstall.
- Candidate profile, Saved, Applied, and notes survive sync.
- Complete-source removal deactivates; partial-source omission does not.
- Deterministic fairness, multiple batches, recent-source exclusion, retry/backoff, and discovery-backlog starvation prevention.
- Conditional 304 advances freshness.

## Validation
- Backend: 212 passed; 85.89% coverage (threshold 85%).
- Ruff: passed.
- MyPy: passed.
- Alembic full upgrade/downgrade: passed.
- Frontend: `npm ci` (0 vulnerabilities), lint passed, 9 unit tests passed, production build passed.
- Windows: fresh PyInstaller build; v1.2.0 installer and portable package built; installed and portable smoke passed; same installed executable synced N -> N+1 without reinstall and preserved local state.
- Real catalog launch gate: passed, 1,281 active European jobs imported with gzip/SHA/schema validation.
- Live N26 validation: already-ingested board selected by due scheduler and fetched again; 65 jobs before/after, no duplicate keys, healthy status retained, `last_ingested_at` advanced.

## Limitations
The approximately 25-hour SLA assumes healthy hourly workflow execution and sources completing within the bounded run. Degraded/failing providers follow explicit retry/backoff and therefore are excluded from the healthy-source bound.