### PR TITLE
Harden market-data durability and prepare v1.2.3

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -228,6 +228,10 @@ jobs:
           fi
           mkdir -p data/catalog data/state
           cp build/publication/data/catalog/* data/catalog/
+          # Every market-data writer must preserve the same shared durable payload.
+          # Publishing only catalog/state here used to erase the rolling registry on
+          # every hourly run, recreating the stale-bootstrap class of failure.
+          cp build/source-registry.latest.json source-registry.latest.json
           if [[ "$BRANCH_BACKED_SQLITE" == "1" ]]; then
             rm -f data/state/daily.sqlite.gz \
               data/state/daily.sqlite.gz.manifest.json \
@@ -250,9 +254,10 @@ jobs:
           # deleting working-tree files before selecting the public payload.
           git read-tree --empty
           # Keep runner-local build databases and generated diagnostics out of the
-          # public data branch; only the catalog and durable state are published.
-          git add data/catalog data/state
-          unexpected=$(git ls-files | grep -Ev '^data/(catalog|state)/' || true)
+          # public data branch; only the shared registry, catalog, and durable state
+          # are published.
+          git add source-registry.latest.json data/catalog data/state
+          unexpected=$(git ls-files | grep -Ev '^(source-registry\.latest\.json|data/(catalog|state)/)' || true)
           if [[ -n "$unexpected" ]]; then
             echo "::error::Refusing to publish unexpected market-data paths:"
             printf '%s\n' "$unexpected"

--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -37,14 +37,35 @@ jobs:
       - name: Restore durable branch-backed state when no database secret is configured
         shell: bash
         run: |
-          mkdir -p build/catalog-seed
-          git fetch origin market-data || true
+          set -euo pipefail
+          mkdir -p build/catalog-seed build/daily-state
+          bash scripts/fetch_market_data.sh
+          if git show-ref --verify --quiet refs/remotes/origin/market-data; then
+            echo "MARKET_DATA_BASE_SHA=$(git rev-parse refs/remotes/origin/market-data)" >> "$GITHUB_ENV"
+          else
+            echo "MARKET_DATA_BASE_SHA=" >> "$GITHUB_ENV"
+          fi
           if [[ -z "$DATABASE_URL" ]]; then
             echo "DATABASE_URL=sqlite:///$GITHUB_WORKSPACE/build/daily.sqlite" >> "$GITHUB_ENV"
             echo "BRANCH_BACKED_SQLITE=1" >> "$GITHUB_ENV"
-            if git cat-file -e origin/market-data:data/state/daily.sqlite.gz 2>/dev/null; then
+            if git cat-file -e origin/market-data:data/state/daily.sqlite.gz.manifest.json 2>/dev/null; then
+              git show origin/market-data:data/state/daily.sqlite.gz.manifest.json \
+                > build/daily-state/daily.sqlite.gz.manifest.json
+              while IFS= read -r chunk; do
+                git show "origin/market-data:data/state/$chunk" > "build/daily-state/$chunk"
+              done < <(
+                python3 scripts/branch_state_archive.py list-chunks \
+                  --manifest build/daily-state/daily.sqlite.gz.manifest.json
+              )
+              python3 scripts/branch_state_archive.py restore \
+                --manifest build/daily-state/daily.sqlite.gz.manifest.json \
+                --output build/daily.sqlite
+              echo "Restored chunked durable SQLite ingestion state from market-data"
+            elif git cat-file -e origin/market-data:data/state/daily.sqlite.gz 2>/dev/null; then
+              # One-release migration path from the legacy single blob. The next
+              # successful publication rewrites it as checksum-verified chunks.
               git show origin/market-data:data/state/daily.sqlite.gz | gzip -dc > build/daily.sqlite
-              echo "Restored durable SQLite ingestion state from market-data"
+              echo "Restored legacy SQLite state; this run will migrate it to chunks"
             else
               echo "No prior SQLite state; this run will bootstrap it"
             fi
@@ -185,12 +206,18 @@ jobs:
               session.commit()
           engine.dispose()
           PY
-          gzip -9 -c build/publication/daily-public.sqlite > build/publication/data/state/daily.sqlite.gz
-          test -s build/publication/data/state/daily.sqlite.gz
+          python scripts/branch_state_archive.py pack \
+            --input build/publication/daily-public.sqlite \
+            --output-dir build/publication/data/state \
+            --prefix daily.sqlite.gz \
+            --chunk-size-mib 48
+          test -s build/publication/data/state/daily.sqlite.gz.manifest.json
+          test -n "$(find build/publication/data/state -name 'daily.sqlite.gz.part-*' -type f -print -quit)"
 
       - name: Persist catalog and state atomically on market-data branch
         shell: bash
         run: |
+          set -euo pipefail
           git config user.name "career-radar-bot"
           git config user.email "career-radar-bot@users.noreply.github.com"
           if git show-ref --verify --quiet refs/remotes/origin/market-data; then
@@ -202,7 +229,11 @@ jobs:
           mkdir -p data/catalog data/state
           cp build/publication/data/catalog/* data/catalog/
           if [[ "$BRANCH_BACKED_SQLITE" == "1" ]]; then
-            cp build/publication/data/state/daily.sqlite.gz data/state/daily.sqlite.gz
+            rm -f data/state/daily.sqlite.gz \
+              data/state/daily.sqlite.gz.manifest.json \
+              data/state/daily.sqlite.gz.part-*
+            cp build/publication/data/state/daily.sqlite.gz.manifest.json data/state/
+            cp build/publication/data/state/daily.sqlite.gz.part-* data/state/
           fi
           python - <<'PY'
           from pathlib import Path
@@ -221,8 +252,15 @@ jobs:
           # Keep runner-local build databases and generated diagnostics out of the
           # public data branch; only the catalog and durable state are published.
           git add data/catalog data/state
+          unexpected=$(git ls-files | grep -Ev '^data/(catalog|state)/' || true)
+          if [[ -n "$unexpected" ]]; then
+            echo "::error::Refusing to publish unexpected market-data paths:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
           git commit -m "data: publish catalog ${GITHUB_RUN_ID}"
-          git push --force origin HEAD:market-data
+          git push --force-with-lease="refs/heads/market-data:${MARKET_DATA_BASE_SHA}" \
+            origin HEAD:market-data
 
       - name: Report upstream source failures after durable publication
         shell: bash

--- a/.github/workflows/source-discovery.yml
+++ b/.github/workflows/source-discovery.yml
@@ -127,10 +127,10 @@ jobs:
             cp build/publication/data/state/discovery.sqlite.gz data/state/discovery.sqlite.gz
           fi
           git checkout --orphan "market-data-discovery-${GITHUB_RUN_ID}"
-          # Source discovery previously used `git add -A` after leaving main, where
-          # .gitignore was no longer present. That silently published runner build
-          # trees and Python caches. Start from an empty index and allowlist only
-          # durable public data plus the rolling registry.
+          # Source discovery previously used catch-all staging after leaving main,
+          # where .gitignore was no longer present. That silently published runner
+          # build trees and Python caches. Start from an empty index and allowlist
+          # only durable public data plus the rolling registry.
           git read-tree --empty
           git add source-registry.latest.json
           if [[ -d data ]]; then

--- a/.github/workflows/source-discovery.yml
+++ b/.github/workflows/source-discovery.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Restore durable branch-backed discovery state when no database secret is configured
         shell: bash
         run: |
+          set -euo pipefail
           mkdir -p build
-          git fetch origin market-data || true
+          bash scripts/fetch_market_data.sh
+          if git show-ref --verify --quiet refs/remotes/origin/market-data; then
+            echo "MARKET_DATA_BASE_SHA=$(git rev-parse refs/remotes/origin/market-data)" >> "$GITHUB_ENV"
+          else
+            echo "MARKET_DATA_BASE_SHA=" >> "$GITHUB_ENV"
+          fi
           if [[ -z "$DATABASE_URL" ]]; then
             echo "DATABASE_URL=sqlite:///$GITHUB_WORKSPACE/build/discovery.sqlite" >> "$GITHUB_ENV"
             echo "BRANCH_BACKED_DISCOVERY=1" >> "$GITHUB_ENV"
@@ -106,6 +112,7 @@ jobs:
       - name: Persist source registry on market-data branch
         shell: bash
         run: |
+          set -euo pipefail
           git config user.name "career-radar-bot"
           git config user.email "career-radar-bot@users.noreply.github.com"
           if git show-ref --verify --quiet refs/remotes/origin/market-data; then
@@ -120,6 +127,21 @@ jobs:
             cp build/publication/data/state/discovery.sqlite.gz data/state/discovery.sqlite.gz
           fi
           git checkout --orphan "market-data-discovery-${GITHUB_RUN_ID}"
-          git add -A
+          # Source discovery previously used `git add -A` after leaving main, where
+          # .gitignore was no longer present. That silently published runner build
+          # trees and Python caches. Start from an empty index and allowlist only
+          # durable public data plus the rolling registry.
+          git read-tree --empty
+          git add source-registry.latest.json
+          if [[ -d data ]]; then
+            git add data
+          fi
+          unexpected=$(git ls-files | grep -Ev '^(source-registry\.latest\.json|data/)' || true)
+          if [[ -n "$unexpected" ]]; then
+            echo "::error::Refusing to publish unexpected market-data paths:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
           git commit -m "data: publish verified source registry ${GITHUB_RUN_ID}"
-          git push --force origin HEAD:market-data
+          git push --force-with-lease="refs/heads/market-data:${MARKET_DATA_BASE_SHA}" \
+            origin HEAD:market-data

--- a/.github/workflows/source-health.yml
+++ b/.github/workflows/source-health.yml
@@ -26,8 +26,14 @@ jobs:
       - name: Restore durable branch-backed health state when no database secret is configured
         shell: bash
         run: |
+          set -euo pipefail
           mkdir -p build
-          git fetch origin market-data || true
+          bash scripts/fetch_market_data.sh
+          if git show-ref --verify --quiet refs/remotes/origin/market-data; then
+            echo "MARKET_DATA_BASE_SHA=$(git rev-parse refs/remotes/origin/market-data)" >> "$GITHUB_ENV"
+          else
+            echo "MARKET_DATA_BASE_SHA=" >> "$GITHUB_ENV"
+          fi
           if [[ -z "$DATABASE_URL" ]]; then
             echo "DATABASE_URL=sqlite:///$GITHUB_WORKSPACE/build/discovery.sqlite" >> "$GITHUB_ENV"
             echo "BRANCH_BACKED_HEALTH=1" >> "$GITHUB_ENV"
@@ -68,6 +74,7 @@ jobs:
         if: env.BRANCH_BACKED_HEALTH == '1'
         shell: bash
         run: |
+          set -euo pipefail
           mkdir -p build/publication/data/state
           cp build/discovery.sqlite build/publication/discovery-public.sqlite
           python - <<'PY'
@@ -108,8 +115,15 @@ jobs:
           if [[ -d data/catalog ]]; then
             git add data/catalog
           fi
+          unexpected=$(git ls-files | grep -Ev '^(source-registry\.latest\.json|data/)' || true)
+          if [[ -n "$unexpected" ]]; then
+            echo "::error::Refusing to publish unexpected market-data paths:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
           git commit -m "data: health checkpoint ${GITHUB_RUN_ID}"
-          git push --force origin HEAD:market-data
+          git push --force-with-lease="refs/heads/market-data:${MARKET_DATA_BASE_SHA}" \
+            origin HEAD:market-data
       - name: Upload retry and health evidence
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/.release/request.json
+++ b/.release/request.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.2.2",
-  "notes_file": ".release/v1.2.2.md"
+  "version": "1.2.3",
+  "notes_file": ".release/v1.2.3.md"
 }

--- a/.release/v1.2.3.md
+++ b/.release/v1.2.3.md
@@ -1,16 +1,17 @@
 ## Career Radar v1.2.3 — Market Data Durability
 
-v1.2.3 hardens the scheduled publication pipeline after a repository-wide workflow audit found two latent failures that had not yet reached production: accidental runner-file publication and an SQLite state blob approaching GitHub's per-file limit.
+v1.2.3 hardens the scheduled publication pipeline after a repository-wide workflow audit found three latent failures: accidental runner-file publication, an SQLite state blob approaching GitHub's per-file limit, and the hourly catalog writer dropping the rolling source registry from the shared `market-data` branch.
 
 ### Fixed
 
 - **Chunked durable SQLite state** — the hourly catalog state is now gzip-compressed and split into checksum-verified 48 MiB chunks with a manifest, removing the single-file growth limit that was about to break `market-data` publication.
 - **Backward-compatible state migration** — the first run can restore the legacy `daily.sqlite.gz` blob, then automatically republishes it in the new chunked format.
 - **Clean source-discovery publication** — source discovery now starts from an empty Git index and allowlists only `data/**` plus `source-registry.latest.json`, preventing build trees, caches, source files, and test files from leaking onto the `market-data` branch.
+- **Rolling registry preservation** — catalog, discovery, and health writers now preserve `source-registry.latest.json` whenever they rewrite the shared orphan branch, so an hourly catalog publication cannot erase the registry used by later discovery/health/bootstrap runs.
 - **Explicit fetch failures** — all three `market-data` writers retry remote discovery/fetch and fail clearly on network errors instead of silently falling back to stale state.
 - **Concurrent-write protection** — `market-data` writers use an exact-SHA force-with-lease so an unexpected external branch update is never overwritten silently.
-- **Regression coverage** — new tests cover chunk round-trips, corruption/missing-chunk rejection, unsafe manifest paths, publication allowlists, retry behavior, and lease protection.
+- **Regression coverage** — new tests cover chunk round-trips, corruption/missing-chunk rejection, unsafe manifest paths, shared-registry preservation, publication allowlists, retry behavior, and lease protection.
 
 ### Validation
 
-This release remains gated on the full Python/backend/frontend CI matrix, PostgreSQL integration, live ATS/browser E2E, security audits, and the Windows installer/portable smoke suite. The first successful hourly ingestion after deployment performs the legacy-to-chunked state migration and removes the oversized legacy blob from the publication branch.
+This release remains gated on the full Python/backend/frontend CI matrix, PostgreSQL integration, live ATS/browser E2E, security audits, and the Windows installer/portable smoke suite. The first successful hourly ingestion after deployment performs the legacy-to-chunked state migration, removes the oversized legacy blob from the publication branch, and rewrites `market-data` using the strict public-data allowlist.

--- a/.release/v1.2.3.md
+++ b/.release/v1.2.3.md
@@ -1,0 +1,16 @@
+## Career Radar v1.2.3 — Market Data Durability
+
+v1.2.3 hardens the scheduled publication pipeline after a repository-wide workflow audit found two latent failures that had not yet reached production: accidental runner-file publication and an SQLite state blob approaching GitHub's per-file limit.
+
+### Fixed
+
+- **Chunked durable SQLite state** — the hourly catalog state is now gzip-compressed and split into checksum-verified 48 MiB chunks with a manifest, removing the single-file growth limit that was about to break `market-data` publication.
+- **Backward-compatible state migration** — the first run can restore the legacy `daily.sqlite.gz` blob, then automatically republishes it in the new chunked format.
+- **Clean source-discovery publication** — source discovery now starts from an empty Git index and allowlists only `data/**` plus `source-registry.latest.json`, preventing build trees, caches, source files, and test files from leaking onto the `market-data` branch.
+- **Explicit fetch failures** — all three `market-data` writers retry remote discovery/fetch and fail clearly on network errors instead of silently falling back to stale state.
+- **Concurrent-write protection** — `market-data` writers use an exact-SHA force-with-lease so an unexpected external branch update is never overwritten silently.
+- **Regression coverage** — new tests cover chunk round-trips, corruption/missing-chunk rejection, unsafe manifest paths, publication allowlists, retry behavior, and lease protection.
+
+### Validation
+
+This release remains gated on the full Python/backend/frontend CI matrix, PostgreSQL integration, live ATS/browser E2E, security audits, and the Windows installer/portable smoke suite. The first successful hourly ingestion after deployment performs the legacy-to-chunked state migration and removes the oversized legacy blob from the publication branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.3 - 2026-09-09
+
+- Replaced the near-limit branch-backed daily SQLite blob with checksum-verified 48 MiB chunks and a manifest, including automatic migration from the legacy single blob.
+- Fixed source discovery so its orphan `market-data` publications can no longer stage runner build trees, caches, source files, or tests.
+- Replaced silent `market-data` fetch fallback with retrying, explicit remote-state checks across catalog, discovery, and health writers.
+- Added exact-SHA force-with-lease publication guards and regression coverage for state integrity and publication allowlists.
+
 ## 1.2.2 - 2026-09-09
 
 - Fixed Source health retry to bootstrap from the rolling market-data registry instead of an aging checked-in snapshot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Replaced the near-limit branch-backed daily SQLite blob with checksum-verified 48 MiB chunks and a manifest, including automatic migration from the legacy single blob.
 - Fixed source discovery so its orphan `market-data` publications can no longer stage runner build trees, caches, source files, or tests.
+- Fixed the hourly catalog writer so rewriting `market-data` preserves `source-registry.latest.json` instead of dropping the rolling source registry required by later health/discovery/bootstrap runs.
 - Replaced silent `market-data` fetch fallback with retrying, explicit remote-state checks across catalog, discovery, and health writers.
-- Added exact-SHA force-with-lease publication guards and regression coverage for state integrity and publication allowlists.
+- Added exact-SHA force-with-lease publication guards and regression coverage for state integrity, shared-registry preservation, and publication allowlists.
 
 ## 1.2.2 - 2026-09-09
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europe-career-radar-web",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,5 +1,5 @@
 #ifndef AppVersion
-  #define AppVersion "1.2.2"
+  #define AppVersion "1.2.3"
 #endif
 #ifndef SourceDir
   #define SourceDir "build\\windows\\app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "europe-visa-sponsorship-jobs"
-version = "1.2.2"
+version = "1.2.3"
 description = "Evidence-based European tech job intelligence for non-EU candidates who need visa sponsorship."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/branch_state_archive.py
+++ b/scripts/branch_state_archive.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+FORMAT = "career-radar-branch-state-v1"
+DEFAULT_CHUNK_SIZE = 48 * 1024 * 1024
+_COPY_BUFFER = 1024 * 1024
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while block := handle.read(_COPY_BUFFER):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _safe_chunk_name(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("state archive manifest contains an invalid chunk name")
+    candidate = Path(value)
+    if candidate.name != value or value in {".", ".."}:
+        raise ValueError(f"unsafe state archive chunk name: {value!r}")
+    return value
+
+
+def pack_archive(
+    source: Path,
+    output_dir: Path,
+    *,
+    prefix: str = "daily.sqlite.gz",
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> Path:
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    if not source.is_file():
+        raise FileNotFoundError(source)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / f"{prefix}.manifest.json"
+    temp_archive = output_dir / f".{prefix}.packing"
+
+    for stale in output_dir.glob(f"{prefix}.part-*"):
+        stale.unlink()
+    manifest_path.unlink(missing_ok=True)
+    temp_archive.unlink(missing_ok=True)
+
+    try:
+        with source.open("rb") as source_handle, temp_archive.open("wb") as raw_handle:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                compresslevel=9,
+                fileobj=raw_handle,
+                mtime=0,
+            ) as compressed:
+                shutil.copyfileobj(source_handle, compressed, length=_COPY_BUFFER)
+
+        chunks: list[dict[str, Any]] = []
+        with temp_archive.open("rb") as archive_handle:
+            index = 0
+            while block := archive_handle.read(chunk_size):
+                name = f"{prefix}.part-{index:03d}"
+                chunk_path = output_dir / name
+                chunk_path.write_bytes(block)
+                chunks.append(
+                    {
+                        "name": name,
+                        "size": len(block),
+                        "sha256": hashlib.sha256(block).hexdigest(),
+                    }
+                )
+                index += 1
+
+        if not chunks:
+            raise ValueError("compressed state archive unexpectedly produced no chunks")
+
+        manifest = {
+            "format": FORMAT,
+            "compression": "gzip",
+            "source_size": source.stat().st_size,
+            "archive_size": temp_archive.stat().st_size,
+            "archive_sha256": _sha256(temp_archive),
+            "chunk_size": chunk_size,
+            "chunks": chunks,
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return manifest_path
+    finally:
+        temp_archive.unlink(missing_ok=True)
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("state archive manifest must be a JSON object")
+    if payload.get("format") != FORMAT:
+        raise ValueError(f"unsupported state archive format: {payload.get('format')!r}")
+    if payload.get("compression") != "gzip":
+        raise ValueError("state archive manifest must use gzip compression")
+    chunks = payload.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        raise ValueError("state archive manifest must contain at least one chunk")
+    return payload
+
+
+def chunk_names(manifest_path: Path) -> list[str]:
+    manifest = _load_manifest(manifest_path)
+    names: list[str] = []
+    for item in manifest["chunks"]:
+        if not isinstance(item, dict):
+            raise ValueError("state archive manifest contains an invalid chunk entry")
+        names.append(_safe_chunk_name(item.get("name")))
+    return names
+
+
+def restore_archive(manifest_path: Path, output: Path) -> None:
+    manifest = _load_manifest(manifest_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_archive = output.with_name(f".{output.name}.archive.tmp")
+    temp_output = output.with_name(f".{output.name}.restore.tmp")
+    temp_archive.unlink(missing_ok=True)
+    temp_output.unlink(missing_ok=True)
+
+    try:
+        with temp_archive.open("wb") as archive_handle:
+            for item in manifest["chunks"]:
+                if not isinstance(item, dict):
+                    raise ValueError("state archive manifest contains an invalid chunk entry")
+                name = _safe_chunk_name(item.get("name"))
+                chunk_path = manifest_path.parent / name
+                if not chunk_path.is_file():
+                    raise FileNotFoundError(chunk_path)
+                expected_size = int(item.get("size", -1))
+                if chunk_path.stat().st_size != expected_size:
+                    raise ValueError(f"state archive chunk size mismatch: {name}")
+                expected_sha = item.get("sha256")
+                if not isinstance(expected_sha, str) or _sha256(chunk_path) != expected_sha:
+                    raise ValueError(f"state archive chunk checksum mismatch: {name}")
+                with chunk_path.open("rb") as chunk_handle:
+                    shutil.copyfileobj(chunk_handle, archive_handle, length=_COPY_BUFFER)
+
+        expected_archive_size = int(manifest.get("archive_size", -1))
+        if temp_archive.stat().st_size != expected_archive_size:
+            raise ValueError("state archive size does not match its manifest")
+        expected_archive_sha = manifest.get("archive_sha256")
+        if not isinstance(expected_archive_sha, str) or _sha256(temp_archive) != expected_archive_sha:
+            raise ValueError("state archive checksum does not match its manifest")
+
+        with gzip.open(temp_archive, "rb") as compressed, temp_output.open("wb") as restored:
+            shutil.copyfileobj(compressed, restored, length=_COPY_BUFFER)
+
+        expected_source_size = int(manifest.get("source_size", -1))
+        if temp_output.stat().st_size != expected_source_size:
+            raise ValueError("restored state size does not match its manifest")
+        temp_output.replace(output)
+    finally:
+        temp_archive.unlink(missing_ok=True)
+        temp_output.unlink(missing_ok=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Pack and restore chunked branch-backed state")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    pack = subparsers.add_parser("pack")
+    pack.add_argument("--input", type=Path, required=True)
+    pack.add_argument("--output-dir", type=Path, required=True)
+    pack.add_argument("--prefix", default="daily.sqlite.gz")
+    pack.add_argument("--chunk-size-mib", type=int, default=48)
+
+    restore = subparsers.add_parser("restore")
+    restore.add_argument("--manifest", type=Path, required=True)
+    restore.add_argument("--output", type=Path, required=True)
+
+    list_chunks = subparsers.add_parser("list-chunks")
+    list_chunks.add_argument("--manifest", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.command == "pack":
+        manifest = pack_archive(
+            args.input,
+            args.output_dir,
+            prefix=args.prefix,
+            chunk_size=args.chunk_size_mib * 1024 * 1024,
+        )
+        print(manifest)
+    elif args.command == "restore":
+        restore_archive(args.manifest, args.output)
+    else:
+        for name in chunk_names(args.manifest):
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/branch_state_archive.py
+++ b/scripts/branch_state_archive.py
@@ -52,15 +52,18 @@ def pack_archive(
     temp_archive.unlink(missing_ok=True)
 
     try:
-        with source.open("rb") as source_handle, temp_archive.open("wb") as raw_handle:
-            with gzip.GzipFile(
+        with (
+            source.open("rb") as source_handle,
+            temp_archive.open("wb") as raw_handle,
+            gzip.GzipFile(
                 filename="",
                 mode="wb",
                 compresslevel=9,
                 fileobj=raw_handle,
                 mtime=0,
-            ) as compressed:
-                shutil.copyfileobj(source_handle, compressed, length=_COPY_BUFFER)
+            ) as compressed,
+        ):
+            shutil.copyfileobj(source_handle, compressed, length=_COPY_BUFFER)
 
         chunks: list[dict[str, Any]] = []
         with temp_archive.open("rb") as archive_handle:

--- a/scripts/fetch_market_data.sh
+++ b/scripts/fetch_market_data.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+branch="${2:-market-data}"
+head_ref="refs/heads/${branch}"
+remote_ref="refs/remotes/${remote}/${branch}"
+
+remote_listing=""
+listing_ok=0
+for attempt in 1 2 3; do
+  if remote_listing=$(git ls-remote --heads "${remote}" "${head_ref}"); then
+    listing_ok=1
+    break
+  fi
+  echo "::warning::Could not query ${remote}/${branch} (attempt ${attempt}/3)"
+  sleep $((attempt * 2))
+done
+
+if [[ "${listing_ok}" != "1" ]]; then
+  echo "::error::Unable to determine whether ${remote}/${branch} exists after 3 attempts"
+  exit 1
+fi
+
+if [[ -z "${remote_listing}" ]]; then
+  echo "::notice::${remote}/${branch} does not exist yet; using cold-start state"
+  exit 0
+fi
+
+for attempt in 1 2 3; do
+  if git fetch --no-tags "${remote}" "${head_ref}:${remote_ref}"; then
+    echo "Fetched ${remote}/${branch}"
+    exit 0
+  fi
+  echo "::warning::Could not fetch ${remote}/${branch} (attempt ${attempt}/3)"
+  sleep $((attempt * 2))
+done
+
+echo "::error::${remote}/${branch} exists but could not be fetched after 3 attempts"
+exit 1

--- a/scripts/validate_release_inputs.py
+++ b/scripts/validate_release_inputs.py
@@ -31,13 +31,33 @@ def _installer_version() -> str:
     return match.group(1)
 
 
+def _validate_web_lock_contract(package: dict, lock: dict) -> None:
+    lock_root = lock.get("packages", {}).get("")
+    if not isinstance(lock_root, dict):
+        raise RuntimeError("web lockfile is missing its root package entry")
+    if lock_root.get("name") != package.get("name"):
+        raise RuntimeError("web lockfile root package name does not match package.json")
+
+    # npm's root package version is descriptive metadata and does not participate
+    # in dependency resolution. Keep the stronger invariant instead: every root
+    # dependency declaration must exactly match package.json. `npm ci` then proves
+    # the complete resolved graph is reproducible without forcing lockfile churn
+    # for a release-only application version bump.
+    for section in ("dependencies", "devDependencies", "optionalDependencies"):
+        expected = package.get(section, {})
+        actual = lock_root.get(section, {})
+        if actual != expected:
+            raise RuntimeError(f"web lockfile {section} do not match package.json")
+
+
 def validate(*, require_snapshot: bool, require_input_hashes: bool = False) -> str:
     backend = _version_from_init()
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
-    web = json.loads((ROOT / "apps/web/package.json").read_text(encoding="utf-8"))["version"]
+    package = json.loads((ROOT / "apps/web/package.json").read_text(encoding="utf-8"))
+    web = package["version"]
     lock = json.loads((ROOT / "apps/web/package-lock.json").read_text(encoding="utf-8"))
-    lock_root = lock["packages"][""]["version"]
-    versions = {"backend": backend, "pyproject": pyproject, "web": web, "web lock": lock_root, "installer": _installer_version()}
+    _validate_web_lock_contract(package, lock)
+    versions = {"backend": backend, "pyproject": pyproject, "web": web, "installer": _installer_version()}
     if len(set(versions.values())) != 1:
         detail = ", ".join(f"{key}={value}" for key, value in versions.items())
         raise RuntimeError(f"release version mismatch: {detail}")

--- a/src/europe_visa_jobs/__init__.py
+++ b/src/europe_visa_jobs/__init__.py
@@ -1,3 +1,3 @@
 """Europe Visa Sponsorship Jobs core package."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/tests/test_branch_state_archive.py
+++ b/tests/test_branch_state_archive.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "branch_state_archive.py"
+_SPEC = importlib.util.spec_from_file_location("branch_state_archive", _SCRIPT)
+assert _SPEC and _SPEC.loader
+branch_state_archive = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(branch_state_archive)
+
+
+def test_chunked_state_archive_round_trip(tmp_path: Path):
+    source = tmp_path / "state.sqlite"
+    payload = bytes(range(256)) * 64
+    source.write_bytes(payload)
+
+    manifest_path = branch_state_archive.pack_archive(
+        source,
+        tmp_path / "publication",
+        chunk_size=128,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["format"] == branch_state_archive.FORMAT
+    assert len(manifest["chunks"]) > 1
+    assert all(chunk["size"] <= 128 for chunk in manifest["chunks"])
+    assert branch_state_archive.chunk_names(manifest_path) == [
+        chunk["name"] for chunk in manifest["chunks"]
+    ]
+
+    restored = tmp_path / "restored.sqlite"
+    branch_state_archive.restore_archive(manifest_path, restored)
+    assert restored.read_bytes() == payload
+
+
+def test_chunked_state_archive_rejects_tampering(tmp_path: Path):
+    source = tmp_path / "state.sqlite"
+    source.write_bytes(bytes(range(128)) * 32)
+    manifest_path = branch_state_archive.pack_archive(
+        source,
+        tmp_path / "publication",
+        chunk_size=96,
+    )
+    first_chunk = manifest_path.parent / branch_state_archive.chunk_names(manifest_path)[0]
+    tampered = bytearray(first_chunk.read_bytes())
+    tampered[0] ^= 0xFF
+    first_chunk.write_bytes(tampered)
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        branch_state_archive.restore_archive(manifest_path, tmp_path / "restored.sqlite")
+
+
+def test_chunked_state_archive_rejects_missing_chunk(tmp_path: Path):
+    source = tmp_path / "state.sqlite"
+    source.write_bytes(b"branch-backed-state" * 512)
+    manifest_path = branch_state_archive.pack_archive(
+        source,
+        tmp_path / "publication",
+        chunk_size=64,
+    )
+    missing = manifest_path.parent / branch_state_archive.chunk_names(manifest_path)[-1]
+    missing.unlink()
+
+    with pytest.raises(FileNotFoundError):
+        branch_state_archive.restore_archive(manifest_path, tmp_path / "restored.sqlite")
+
+
+def test_chunked_state_archive_rejects_unsafe_chunk_names(tmp_path: Path):
+    manifest_path = tmp_path / "daily.sqlite.gz.manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "format": branch_state_archive.FORMAT,
+                "compression": "gzip",
+                "source_size": 1,
+                "archive_size": 1,
+                "archive_sha256": "0" * 64,
+                "chunk_size": 1,
+                "chunks": [{"name": "../escape", "size": 1, "sha256": "0" * 64}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsafe"):
+        branch_state_archive.chunk_names(manifest_path)

--- a/tests/test_market_data_workflows.py
+++ b/tests/test_market_data_workflows.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _workflow(name: str) -> str:
+    root = Path(__file__).resolve().parents[1]
+    return (root / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_all_market_data_writers_use_retrying_fetch_and_lease_protection():
+    for name in ("daily-ingest.yml", "source-discovery.yml", "source-health.yml"):
+        workflow = _workflow(name)
+        assert "bash scripts/fetch_market_data.sh" in workflow
+        assert "MARKET_DATA_BASE_SHA=" in workflow
+        assert "git push --force-with-lease=" in workflow
+        assert "git push --force origin HEAD:market-data" not in workflow
+        assert "git fetch origin market-data || true" not in workflow
+
+
+def test_source_discovery_publishes_only_public_data_allowlist():
+    workflow = _workflow("source-discovery.yml")
+    assert "git read-tree --empty" in workflow
+    assert "git add source-registry.latest.json" in workflow
+    assert "git add data" in workflow
+    assert "Refusing to publish unexpected market-data paths" in workflow
+    assert "git add -A" not in workflow
+
+
+def test_daily_state_migrates_legacy_blob_to_chunked_archive():
+    workflow = _workflow("daily-ingest.yml")
+    assert "daily.sqlite.gz.manifest.json" in workflow
+    assert "branch_state_archive.py list-chunks" in workflow
+    assert "branch_state_archive.py restore" in workflow
+    assert "branch_state_archive.py pack" in workflow
+    assert "--chunk-size-mib 48" in workflow
+    assert "daily.sqlite.gz.part-*" in workflow
+    assert "Restored legacy SQLite state" in workflow
+    assert "rm -f data/state/daily.sqlite.gz" in workflow
+    assert "Refusing to publish unexpected market-data paths" in workflow
+
+
+def test_market_data_fetch_helper_never_silently_downgrades_network_failure():
+    root = Path(__file__).resolve().parents[1]
+    helper = (root / "scripts" / "fetch_market_data.sh").read_text(encoding="utf-8")
+    assert "for attempt in 1 2 3" in helper
+    assert "Unable to determine whether" in helper
+    assert "exists but could not be fetched" in helper
+    assert "|| true" not in helper

--- a/tests/test_market_data_workflows.py
+++ b/tests/test_market_data_workflows.py
@@ -18,6 +18,19 @@ def test_all_market_data_writers_use_retrying_fetch_and_lease_protection():
         assert "git fetch origin market-data || true" not in workflow
 
 
+def test_every_market_data_writer_preserves_the_rolling_registry():
+    for name in ("daily-ingest.yml", "source-discovery.yml", "source-health.yml"):
+        workflow = _workflow(name)
+        assert "source-registry.latest.json" in workflow
+        assert "git add source-registry.latest.json" in workflow or (
+            "git add data/state source-registry.latest.json" in workflow
+        )
+
+    daily = _workflow("daily-ingest.yml")
+    assert "cp build/source-registry.latest.json source-registry.latest.json" in daily
+    assert "git add source-registry.latest.json data/catalog data/state" in daily
+
+
 def test_source_discovery_publishes_only_public_data_allowlist():
     workflow = _workflow("source-discovery.yml")
     assert "git read-tree --empty" in workflow

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -141,7 +141,7 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert worst_case_hours <= 25
 
     assert "git read-tree --empty" in daily
-    assert "git add data/catalog data/state" in daily
+    assert "git add source-registry.latest.json data/catalog data/state" in daily
     assert "git add -A" not in daily
     assert "summary[\"sources_failed\"] and not summary[\"partial_success\"]" in daily
 

--- a/tests/test_release_inputs.py
+++ b/tests/test_release_inputs.py
@@ -19,14 +19,14 @@ _SIGNING_SPEC.loader.exec_module(windows_signing_mode)
 
 
 def test_release_version_sources_match():
-    assert validate_release_inputs.validate(require_snapshot=False) == "1.2.2"
+    assert validate_release_inputs.validate(require_snapshot=False) == "1.2.3"
 
 
 def test_release_validation_accepts_the_real_snapshot():
     # The checked-in snapshot is a portable release fallback. Its structure and
     # minimum verified-board count must remain valid even after wall-clock age
     # advances; scheduled runtime workflows use the rolling market-data snapshot.
-    assert validate_release_inputs.validate(require_snapshot=True) == "1.2.2"
+    assert validate_release_inputs.validate(require_snapshot=True) == "1.2.3"
 
 
 def test_release_validation_can_require_sponsor_provenance_hashes(monkeypatch):
@@ -38,7 +38,7 @@ def test_release_validation_can_require_sponsor_provenance_hashes(monkeypatch):
         return {}
 
     monkeypatch.setattr(validate_release_inputs, "validate_registry", fake_validate_registry)
-    assert validate_release_inputs.validate(require_snapshot=False, require_input_hashes=True) == "1.2.2"
+    assert validate_release_inputs.validate(require_snapshot=False, require_input_hashes=True) == "1.2.3"
     assert called["kwargs"]["require_input_hashes"] is True
 
 
@@ -144,6 +144,14 @@ def test_scheduled_workflows_use_durable_source_state_and_compressed_sponsors():
     assert "git add data/catalog data/state" in daily
     assert "git add -A" not in daily
     assert "summary[\"sources_failed\"] and not summary[\"partial_success\"]" in daily
+
+    # Source discovery writes the same public branch and must keep the exact same
+    # allowlist discipline. This closes the gap that let runner build trees leak
+    # into market-data even while daily and health publication tests stayed green.
+    assert "git read-tree --empty" in discovery
+    assert "git add source-registry.latest.json" in discovery
+    assert "git add data" in discovery
+    assert "git add -A" not in discovery
 
     # Provider/source outages are health evidence, not runner failures. Even an
     # all-failed retry batch must stay a warning after the preceding persistence


### PR DESCRIPTION
## Why

A repository-wide scheduled-workflow audit found three latent durability failures:

1. `source-discovery.yml` used catch-all staging after switching to an orphan `market-data` publication branch. Because `.gitignore` is no longer present there, runner-local `build/`, `src/`, migrations, caches, bytecode, and diagnostics were published accidentally. The current `market-data` branch visibly contains this pollution.
2. `data/state/daily.sqlite.gz` has grown to 104,482,840 bytes, leaving only 374,760 bytes below GitHub's 100 MiB per-file hard limit. A near-future hourly publication would fail even if ingestion itself were healthy.
3. The hourly catalog writer rebuilt `market-data` from only catalog/state paths, which could erase `source-registry.latest.json`. That rolling registry is the authoritative bootstrap for later catalog, discovery, and source-health runs, so this recreated the same stale-bootstrap failure class from another path.

## Fix

- replace the monolithic daily SQLite blob with a checksum-verified, manifest-backed 48 MiB chunk format;
- preserve one-run backward compatibility with the existing legacy blob and automatically migrate it on the next successful hourly publication;
- make source-discovery publication start from an empty Git index with a strict public-data allowlist;
- make all three `market-data` writers preserve `source-registry.latest.json` and the shared durable payload;
- add explicit unexpected-path guards to all public branch writers;
- replace silent fetch fallback with a shared 3-attempt remote probe/fetch helper that distinguishes a missing cold-start branch from a real network failure;
- protect all forced orphan publications with exact-SHA `--force-with-lease`;
- add corruption, missing-chunk, path-traversal, shared-registry, workflow allowlist, fetch retry, and publication lease regressions;
- prepare v1.2.3 release metadata.

## Release validation

Do not merge unless the full PR CI matrix and Windows desktop package are green. After merge, run the real hourly catalog workflow and inspect `market-data` to prove the legacy blob migrated to chunks, the pollution disappeared, the catalog survived, and `source-registry.latest.json` remains present. The normal release workflow then waits for CI and Windows packaging on the exact main commit before publishing v1.2.3.